### PR TITLE
test: fix test numbering gaps and consolidate chain-config assertions

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -194,7 +194,7 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 		expect(challenge["destination"]).toBe(WALLET);
 	});
 
-	test("3. Idempotent access request returns same challenge", async () => {
+	test("2. Idempotent access request returns same challenge", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
 		const { executor } = createAgentGate({ config, adapter });
@@ -216,7 +216,7 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 		expect(c1["challengeId"]).toBe(c2["challengeId"]);
 	});
 
-	test("4. Resource not found returns failed task", async () => {
+	test("3. Resource not found returns failed task", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
 		const { executor } = createAgentGate({ config, adapter });
@@ -236,7 +236,7 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 		expect(textPart.text).toContain("not found");
 	});
 
-	test("6. Default resourceId when not provided", async () => {
+	test("4. Default resourceId when not provided", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
 		const { executor } = createAgentGate({ config, adapter });

--- a/src/adapter/__tests__/chain-config.test.ts
+++ b/src/adapter/__tests__/chain-config.test.ts
@@ -2,35 +2,27 @@ import { describe, expect, test } from "bun:test";
 import { CHAIN_CONFIGS } from "../chain-config.js";
 
 describe("CHAIN_CONFIGS", () => {
-	test("testnet has correct chainId", () => {
-		expect(CHAIN_CONFIGS.testnet.chainId).toBe(84532);
+	test("testnet config matches Base Sepolia", () => {
+		expect(CHAIN_CONFIGS.testnet).toEqual({
+			name: "testnet",
+			chainId: 84532,
+			rpcUrl: "https://sepolia.base.org",
+			usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			usdcDomain: { name: "USDC", version: "2" },
+			explorerBaseUrl: "https://sepolia.basescan.org",
+			facilitatorUrl: "https://api.cdp.coinbase.com/platform/v2/x402",
+		});
 	});
 
-	test("mainnet has correct chainId", () => {
-		expect(CHAIN_CONFIGS.mainnet.chainId).toBe(8453);
-	});
-
-	test("testnet has Base Sepolia RPC", () => {
-		expect(CHAIN_CONFIGS.testnet.rpcUrl).toBe("https://sepolia.base.org");
-	});
-
-	test("mainnet has Base RPC", () => {
-		expect(CHAIN_CONFIGS.mainnet.rpcUrl).toBe("https://mainnet.base.org");
-	});
-
-	test("testnet USDC address is correct", () => {
-		expect(CHAIN_CONFIGS.testnet.usdcAddress).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e");
-	});
-
-	test("mainnet USDC address is correct", () => {
-		expect(CHAIN_CONFIGS.mainnet.usdcAddress).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
-	});
-
-	test("testnet explorer URL", () => {
-		expect(CHAIN_CONFIGS.testnet.explorerBaseUrl).toBe("https://sepolia.basescan.org");
-	});
-
-	test("mainnet explorer URL", () => {
-		expect(CHAIN_CONFIGS.mainnet.explorerBaseUrl).toBe("https://basescan.org");
+	test("mainnet config matches Base", () => {
+		expect(CHAIN_CONFIGS.mainnet).toEqual({
+			name: "mainnet",
+			chainId: 8453,
+			rpcUrl: "https://mainnet.base.org",
+			usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+			usdcDomain: { name: "USDC", version: "2" },
+			explorerBaseUrl: "https://basescan.org",
+			facilitatorUrl: "https://api.cdp.coinbase.com/platform/v2/x402",
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Renumber e2e tests from `1/3/4/6` → `1/2/3/4` (fill gaps left by previously removed tests)
- Consolidate `chain-config.test.ts` from 8 individual property assertions into 2 `toEqual` checks — now also covers the previously untested `name`, `usdcDomain`, and `facilitatorUrl` fields

## Test plan

- [ ] `bun test src/__tests__/e2e.test.ts` — 4 passing
- [ ] `bun test src/adapter/__tests__/chain-config.test.ts` — 2 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)