### PR TITLE
fix: correct example configurations

### DIFF
--- a/examples/client-agent/agent.ts
+++ b/examples/client-agent/agent.ts
@@ -113,7 +113,7 @@ async function main() {
 	// -----------------------------------------------------------------------
 	console.log("2. Requesting access...");
 	const requestId = crypto.randomUUID();
-	const basePath = "/agent";
+	const basePath = "/a2a/jsonrpc";
 
 	const accessRes = await fetch(`${SELLER_URL}${basePath}`, {
 		method: "POST",

--- a/examples/express-seller/server.ts
+++ b/examples/express-seller/server.ts
@@ -1,4 +1,4 @@
-import { AccessTokenIssuer, RedisSeenTxStore, X402Adapter } from "@riklr/agentgate";
+import { AccessTokenIssuer, X402Adapter } from "@riklr/agentgate";
 import type { NetworkName } from "@riklr/agentgate";
 import { agentGateRouter, validateAccessToken } from "@riklr/agentgate/express";
 import express from "express";
@@ -104,7 +104,7 @@ app.get("/api/photos/:id", (req, res) => {
 app.listen(PORT, () => {
 	console.log(`\nPhoto Gallery Agent running on ${PUBLIC_URL}`);
 	console.log(`  Agent card: ${PUBLIC_URL}/.well-known/agent.json`);
-	console.log(`  A2A endpoint: ${PUBLIC_URL}/agent`);
+	console.log(`  A2A endpoint: ${PUBLIC_URL}/a2a/jsonrpc`);
 	console.log(`  Network: ${NETWORK}`);
 	console.log(`  Wallet: ${WALLET}\n`);
 });

--- a/examples/hono-seller/server.ts
+++ b/examples/hono-seller/server.ts
@@ -101,6 +101,6 @@ export default {
 
 console.log(`\nPhoto Gallery Agent (Hono) running on http://localhost:${PORT}`);
 console.log(`  Agent card: http://localhost:${PORT}/.well-known/agent.json`);
-console.log(`  A2A endpoint: http://localhost:${PORT}/agent`);
+console.log(`  A2A endpoint: http://localhost:${PORT}/a2a/jsonrpc`);
 console.log(`  Network: ${NETWORK}`);
 console.log(`  Wallet: ${WALLET}\n`);

--- a/examples/refund-cron-example/server.ts
+++ b/examples/refund-cron-example/server.ts
@@ -75,16 +75,10 @@ app.use(
 				return ["item-1", "item-2", "item-3"].includes(resourceId);
 			},
 			onIssueToken: async (params) => {
-				return tokenIssuer.sign(
-					{
-						sub: params.requestId,
-						jti: params.challengeId,
-						resourceId: params.resourceId,
-						tierId: params.tierId,
-						txHash: params.txHash,
-					},
-					3600,
-				);
+				console.log("New token issued", params);
+				// Intentionally throw to simulate token issuance failure,
+				// so the refund cron has undelivered payments to process.
+				throw new Error("No Token Issued");
 			},
 			onPaymentReceived: async (grant) => {
 				console.log(`[Payment] Received payment for ${grant.resourceId}`);

--- a/examples/refund-cron-example/server.ts
+++ b/examples/refund-cron-example/server.ts
@@ -76,9 +76,19 @@ app.use(
 			},
 			onIssueToken: async (params) => {
 				console.log("New token issued", params);
-				// Intentionally throw to simulate token issuance failure,
-				// so the refund cron has undelivered payments to process.
-				throw new Error("No Token Issued");
+				throw new Error("No Token Issued"); // NOTE: This is for testing the refund cron
+
+				// NOTE: This is the original code that issues a token
+				// return tokenIssuer.sign(
+				// 	{
+				// 		sub: params.requestId,
+				// 		jti: params.challengeId,
+				// 		resourceId: params.resourceId,
+				// 		tierId: params.tierId,
+				// 		txHash: params.txHash,
+				// 	},
+				// 	3600,
+				// );
 			},
 			onPaymentReceived: async (grant) => {
 				console.log(`[Payment] Received payment for ${grant.resourceId}`);

--- a/examples/refund-cron-example/server.ts
+++ b/examples/refund-cron-example/server.ts
@@ -75,20 +75,16 @@ app.use(
 				return ["item-1", "item-2", "item-3"].includes(resourceId);
 			},
 			onIssueToken: async (params) => {
-				console.log("New token issued", params);
-				throw new Error("No Token Issued"); // NOTE: This is for testing the refund cron
-
-				// NOTE: This is the original code that issues a token
-				// return tokenIssuer.sign(
-				// 	{
-				// 		sub: params.requestId,
-				// 		jti: params.challengeId,
-				// 		resourceId: params.resourceId,
-				// 		tierId: params.tierId,
-				// 		txHash: params.txHash,
-				// 	},
-				// 	3600,
-				// );
+				return tokenIssuer.sign(
+					{
+						sub: params.requestId,
+						jti: params.challengeId,
+						resourceId: params.resourceId,
+						tierId: params.tierId,
+						txHash: params.txHash,
+					},
+					3600,
+				);
 			},
 			onPaymentReceived: async (grant) => {
 				console.log(`[Payment] Received payment for ${grant.resourceId}`);

--- a/examples/simple-x402-client.ts
+++ b/examples/simple-x402-client.ts
@@ -101,9 +101,9 @@ async function main() {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({
-			tier: pricing.tierId,
+			tierId: pricing.tierId,
 			requestId,
-			resource: "photo-1",
+			resourceId: "photo-1",
 		}),
 	});
 
@@ -179,9 +179,9 @@ async function main() {
 			"PAYMENT-SIGNATURE": paymentSignatureHeader,
 		},
 		body: JSON.stringify({
-			tier: pricing.tierId,
+			tierId: pricing.tierId,
 			requestId,
-			resource: "photo-1",
+			resourceId: "photo-1",
 		}),
 	});
 


### PR DESCRIPTION
## Summary

- **`client-agent/agent.ts`**: Fix endpoint path `/agent` → `/a2a/jsonrpc` (server registers at `basePath/jsonrpc`, default `/a2a/jsonrpc`)
- **`express-seller` / `hono-seller`**: Fix startup log to show correct A2A endpoint path
- **`express-seller`**: Remove unused `RedisSeenTxStore` import
- **`simple-x402-client.ts`**: Fix request body field names `tier` → `tierId` and `resource` → `resourceId` to match server destructuring
- **`refund-cron-example`**: Remove testing artifact (`throw new Error("No Token Issued")`), restore real token issuance

## Test plan

- [ ] Run `cd examples/express-seller && bun run start` — verify log shows `/a2a/jsonrpc`
- [ ] Run `cd examples/client-agent && bun run start` against the express-seller — verify full payment flow completes
- [ ] Run `WALLET_PRIVATE_KEY=0x... bun run examples/simple-x402-client.ts` — verify no 400 on access request
- [ ] Run `cd examples/refund-cron-example && bun run start` — verify tokens are issued successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)