### PR TITLE
feat: e2e test suite + gas wallet refund fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: bun run lint
 
       - name: Test
-        run: bun test --recursive
+        run: bun test src/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,56 @@
+name: E2E Tests (Base Sepolia)
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - ".claude/**"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install e2e dependencies
+        run: bun install --frozen-lockfile
+        working-directory: e2e
+
+      - name: Build Docker image
+        run: docker build -t agentgate-e2e .
+
+      - name: Run e2e tests
+        working-directory: e2e
+        run: bun test --preload ./global-setup.ts --timeout 60000
+        env:
+          CLIENT_WALLET_ADDRESS: ${{ secrets.CLIENT_WALLET_ADDRESS }}
+          CLIENT_WALLET_PRIVATE_KEY: ${{ secrets.CLIENT_WALLET_PRIVATE_KEY }}
+          GAS_WALLET_ADDRESS: ${{ secrets.GAS_WALLET_ADDRESS }}
+          GAS_WALLET_PRIVATE_KEY: ${{ secrets.GAS_WALLET_PRIVATE_KEY }}
+          AGENTGATE_WALLET_ADDRESS: ${{ secrets.AGENTGATE_WALLET_ADDRESS }}
+          AGENTGATE_WALLET_KEY: ${{ secrets.AGENTGATE_WALLET_KEY }}
+          ALCHEMY_BASE_SEPOLIA_RPC_URL: ${{ secrets.ALCHEMY_BASE_SEPOLIA_RPC_URL }}
+
+      - name: Upload logs on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-logs-${{ github.run_id }}
+          path: |
+            e2e/logs/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Client → Protected API with Bearer JWT
 1. **Types** (`src/types/`) — Protocol-agnostic interfaces: `IPaymentAdapter`, `IChallengeStore`, `ISeenTxStore`, plus all message types (`AccessRequest`, `X402Challenge`, `PaymentProof`, `AccessGrant`).
 
 2. **Core** (`src/core/`) — Business logic:
-   - `challenge-engine.ts` — State machine (PENDING → PAID/EXPIRED/CANCELLED). Owns the full challenge lifecycle, on-chain verification dispatch, and token issuance.
+   - `challenge-engine.ts` — State machine (PENDING → PAID → DELIVERED | PENDING → EXPIRED | PENDING → CANCELLED | PAID → REFUND_PENDING → REFUNDED | PAID → REFUND_PENDING → REFUND_FAILED). Owns the full challenge lifecycle, on-chain verification dispatch, and token issuance.
    - `access-token.ts` — JWT issuance/verification (HS256 or RS256). Supports fallback secrets for zero-downtime rotation.
    - `agent-card.ts` — Auto-generates A2A discovery card from `SellerConfig`.
    - `storage/` — `IChallengeStore` + `ISeenTxStore` with Redis implementations (`RedisChallengeStore`, `RedisSeenTxStore`). Uses atomic Lua scripts for concurrent state transitions. Both are required fields.

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ bun run start
 ```bash
 bun install          # Install dependencies
 bun run typecheck    # Type-check
-bun run lint         # Lint with Biome
+bun run lint         # Lint with Biome v2
 bun test             # Run all tests
 bun run build        # Compile to ./dist
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run AgentGate as a pre-built Docker container. No code required — configure en
 │  discover    │───────▶│  /.well-known/agent.json  │        │                  │
 │              │◀───────│  agent card + pricing      │        │                  │
 │              │        │                           │        │                  │
-│  request     │───────▶│  /a2a/access              │        │                  │
+│  request     │───────▶│  /x402/access             │        │                  │
 │              │        │  [store: PENDING]         │        │                  │
 │              │◀───────│  402 + payment terms       │        │                  │
 │              │        │                           │        │                  │
@@ -97,7 +97,7 @@ Build from source: `docker build -t riklr/agentgate .`
 | `PROVIDER_URL` | | `https://agentgate.dev` | Your organization URL shown in the agent card `provider` field |
 | `PRODUCTS` | | `[{"tierId":"basic","label":"Basic","amount":"$0.10","resourceType":"api","accessDurationSeconds":3600}]` | JSON array of pricing tiers — each with `tierId`, `label`, `amount`, `resourceType`, and optional `accessDurationSeconds` |
 | `CHALLENGE_TTL_SECONDS` | | `900` | How long a payment challenge remains valid before expiring (seconds) |
-| `BASE_PATH` | ✅ | — | URL path prefix for A2A endpoints (e.g. `/a2a` mounts `/a2a/access` and `/a2a/.well-known/agent.json`) |
+| `BASE_PATH` | ✅ | — | URL path prefix for A2A endpoints (e.g. `/a2a` mounts `/a2a/jsonrpc` and `/a2a/.well-known/agent.json`) |
 | `ISSUE_TOKEN_API_SECRET` | | — | If set, sent as `Authorization: Bearer <secret>` on every request to `ISSUE_TOKEN_API` |
 | `REDIS_URL` | ✅ | — | Redis connection URL — required for multi-replica deployments and the BullMQ refund cron |
 | `GAS_WALLET_PRIVATE_KEY` | | — | Private key of a wallet holding ETH on Base — enables self-contained settlement without a CDP facilitator |
@@ -185,7 +185,7 @@ Install the SDK and add AgentGate as middleware inside your existing application
 │              │        │  ┌────────────────────────────────────────────┐  │
 │  discover    │───────▶│  │           AgentGate Middleware              │  │
 │              │◀───────│  │  /.well-known/agent.json  (auto-generated)  │  │
-│              │        │  │  /a2a/access  (x402 payment + settlement)   │  │
+│              │        │  │  /x402/access  (x402 payment + settlement)  │  │
 │  request     │───────▶│  │  onVerifyResource()  ──▶  your DB/logic     │  │
 │              │        │  │  [store: PENDING]                          │  │
 │              │◀───────│  │  402 + payment terms                        │  │
@@ -345,6 +345,7 @@ fastify.listen({ port: 3000 });
 | `basePath` | `string` | | `"/a2a"` | A2A endpoint path prefix |
 | `resourceEndpointTemplate` | `string` | | auto | URL template (use `{resourceId}`) |
 | `gasWalletPrivateKey` | `0x${string}` | | — | Private key for self-contained settlement |
+| `redis` | `IRedisLockClient` | | — | Redis client for distributed gas wallet settlement locking across replicas |
 | `facilitatorUrl` | `string` | | CDP default | Override the x402 facilitator URL |
 | `onPaymentReceived` | `(grant) => Promise<void>` | | — | Fired after successful payment |
 | `onChallengeExpired` | `(challengeId) => Promise<void>` | | — | Fired when a challenge expires |

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ bun run start
 bun install          # Install dependencies
 bun run typecheck    # Type-check
 bun run lint         # Lint with Biome v2
-bun test             # Run all tests
+bun test src/        # Run unit tests (e2e tests require separate setup — see e2e/)
 bun run build        # Compile to ./dist
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -1,11 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
 	"files": {
-		"ignore": [".claude/"]
+		"includes": ["**", "!.claude"]
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -14,15 +12,14 @@
 				"noNonNullAssertion": "off"
 			},
 			"complexity": {
-				"useLiteralKeys": "off"
+				"useLiteralKeys": "off",
+				"noUselessContinue": "off"
 			},
 			"suspicious": {
 				"noImplicitAnyLet": "warn",
 				"noExplicitAny": "off"
 			},
-			"correctness": {
-				"noUnnecessaryContinue": "off"
-			}
+			"correctness": {}
 		}
 	},
 	"formatter": {

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -125,6 +125,7 @@ app.use(
 			onVerifyResource: async () => true,
 			onIssueToken,
 			...(GAS_WALLET_PRIVATE_KEY ? { gasWalletPrivateKey: GAS_WALLET_PRIVATE_KEY } : {}),
+			redis,
 		},
 		adapter,
 		store,

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -11,10 +11,10 @@ import {
 	type IChallengeStore,
 	type NetworkName,
 	type ProductTier,
+	processRefunds,
 	RedisChallengeStore,
 	RedisSeenTxStore,
 	X402Adapter,
-	processRefunds,
 } from "@riklr/agentgate";
 import { agentGateRouter } from "@riklr/agentgate/express";
 import express from "express";

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -153,6 +153,7 @@ async function runRefundCron(): Promise<void> {
 	const results = await processRefunds({
 		store,
 		walletPrivateKey: WALLET_PRIVATE_KEY,
+		gasWalletPrivateKey: GAS_WALLET_PRIVATE_KEY,
 		network: NETWORK,
 		minAgeMs: REFUND_MIN_AGE_MS,
 	});

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,23 @@
+# ─── Required: Test wallets ───────────────────────────────────────────────────
+
+# Primary test wallet — sends USDC transfers / EIP-3009 authorizations
+CLIENT_WALLET_ADDRESS=0xYourClientWalletHere
+CLIENT_WALLET_PRIVATE_KEY=0xYourClientPrivateKeyHere
+
+# Secondary wallet — gas wallet for AgentGate settlement + second concurrent buyer
+GAS_WALLET_ADDRESS=0xYourGasWalletHere
+GAS_WALLET_PRIVATE_KEY=0xYourGasWalletPrivateKeyHere
+
+# AgentGate seller wallet — receives USDC payments, sends refunds
+AGENTGATE_WALLET_ADDRESS=0xYourAgentGateWalletHere
+AGENTGATE_WALLET_KEY=0xYourAgentGateWalletPrivateKeyHere
+
+# ─── Optional: RPC ────────────────────────────────────────────────────────────
+
+# Reliable Alchemy RPC for Base Sepolia (fallback: public sepolia.base.org)
+# ALCHEMY_BASE_SEPOLIA_RPC_URL=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+
+# ─── Optional: TTL ────────────────────────────────────────────────────────────
+
+# Challenge TTL for the short-TTL stack used in challenge-timeout.test.ts (default: 5)
+# E2E_SHORT_CHALLENGE_TTL=5

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,190 @@
+# AgentGate E2E Test Suite
+
+End-to-end tests that run the real AgentGate Docker container against Base Sepolia testnet. Every test exercises the full stack: HTTP layer → challenge engine → Redis storage → on-chain USDC settlement.
+
+## Architecture
+
+```
+Test Process (Bun)
+  ├── Backend Server (in-process Express, port 3001)
+  │     ├── POST /internal/issue-token   ← controllable: success | fail
+  │     ├── POST /test/set-mode          ← switches backend behaviour per-test
+  │     └── GET  /api/resource/:id       ← protected API (validates Bearer JWT)
+  │
+  ├── Docker: agentgate (port 3000)
+  │     env: ISSUE_TOKEN_API → http://host.docker.internal:3001/internal/issue-token
+  │
+  ├── Docker: redis:7-alpine (port 6380)
+  │     ← AgentGate stores challenge state here
+  │     ← Tests read/write state directly via ioredis for setup and assertions
+  │
+  └── E2eTestClient (viem, EIP-3009)
+        1. POST /a2a/access (no payment)     → HTTP 402 + challengeId
+        2. signTypedData(TransferWithAuth)   → off-chain EIP-3009 signature
+        3. POST /a2a/access (payment-signature header) → gas wallet settles → AccessGrant (JWT)
+        4. GET  /api/resource/:id (Bearer)   → protected backend API
+```
+
+## Prerequisites
+
+- Docker Desktop running
+- Node / Bun installed
+- Funded test wallets on Base Sepolia (see `.env.example`)
+
+## Running
+
+```bash
+# Run all e2e tests (starts Docker stack automatically)
+cd e2e
+bun run test
+
+# Run a single scenario
+bun test scenarios/happy-path.test.ts --preload ./global-setup.ts
+
+# Fast check — no wallet needed
+bun test scenarios/agent-card.test.ts --preload ./global-setup.ts
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in the values:
+
+| Variable | Description |
+|---|---|
+| `CLIENT_WALLET_PRIVATE_KEY` | Signs EIP-3009 authorizations (buyer) |
+| `CLIENT_WALLET_ADDRESS` | Buyer address |
+| `GAS_WALLET_PRIVATE_KEY` | Pays gas for on-chain settlement; also second buyer in concurrent test |
+| `GAS_WALLET_ADDRESS` | Gas wallet address |
+| `AGENTGATE_WALLET_ADDRESS` | Receives USDC payments; signs EIP-3009 for refunds |
+| `AGENTGATE_WALLET_KEY` | AGENTGATE wallet private key (for signing refund authorizations) |
+| `ALCHEMY_BASE_SEPOLIA_RPC_URL` | Reliable RPC — Alchemy or equivalent |
+
+## Test Scenarios
+
+### `agent-card.test.ts` — Agent Card (2 tests)
+
+Verifies the `GET /.well-known/agent.json` discovery document.
+
+- Checks the response shape: `name`, `description`, `url`, a `skills` array, and a `capabilities.extensions` entry that declares the x402 extension as `required: true`.
+- Checks the `"basic"` skill's pricing: `amount` is a dollar string (`"$0.10"`), `chainId` is `84532` (Base Sepolia).
+
+No wallet or on-chain interaction needed.
+
+---
+
+### `happy-path.test.ts` — Happy Path (3 tests)
+
+The full purchase flow where everything works correctly.
+
+**Main test (purchase → JWT → protected API):**
+1. `POST /a2a/access` with no payment → server returns HTTP 402 with `challengeId` and payment requirements in a base64-encoded `payment-required` header.
+2. Client signs an EIP-3009 `TransferWithAuthorization` off-chain — authorizes the gas wallet to move USDC from the client's address to the AgentGate wallet.
+3. `POST /a2a/access` with `payment-signature` header containing the EIP-3009 signature → gas wallet executes the on-chain transfer → server issues an `AccessGrant` (JWT).
+4. `GET /api/resource/resource-1` with `Authorization: Bearer <jwt>` → backend returns 200 with resource data.
+
+**Also tests:**
+- No token → 401
+- Invalid token → 401
+
+---
+
+### `challenge-timeout.test.ts` — Challenge Timeout (1 test)
+
+Verifies that idempotency resets after a challenge TTL expires.
+
+Instead of waiting 300 seconds for the real TTL, it deletes the `agentgate:request:{requestId}` index key from Redis directly — simulating expiry. The second `requestAccess` call with the same `requestId` creates a new challenge with a different `challengeId`, proving the idempotency window is bounded by the key's TTL.
+
+---
+
+### `double-spend.test.ts` — Double Spend Protection (1 test)
+
+Verifies that a signed EIP-3009 authorization cannot be reused across two challenges.
+
+Does a full purchase and gets a grant. Then submits the exact same `payment-signature` on a new challenge. The server rejects it with `TX_ALREADY_REDEEMED`. Prevention relies on the `agentgate:seentx:{nonce}` SET NX key in Redis — once a nonce is recorded, the same value can never claim a second challenge.
+
+---
+
+### `wrong-amount.test.ts` — Wrong Amount (1 test)
+
+Verifies that underpayment is rejected before any state is committed.
+
+Signs an EIP-3009 authorization for `1n` micro-USDC (far below the required `100_000n` / $0.10). Settlement rejects it with `AMOUNT_INSUFFICIENT` — the `value` field in the authorization is checked against the required amount before the on-chain call is made.
+
+---
+
+### `wrong-recipient.test.ts` — Wrong Recipient (1 test)
+
+Verifies that payment directed to the wrong address is rejected.
+
+Signs an EIP-3009 authorization with the `to` field set to a random address instead of the AgentGate wallet address. Settlement rejects it with `WRONG_RECIPIENT` — the `payTo` in the authorization must match `config.walletAddress`.
+
+---
+
+### `invalid-tier.test.ts` — Invalid Tier (1 test)
+
+Verifies that requesting an unknown tier fails immediately — before any payment requirements are issued.
+
+Calls `requestAccess` with `tierId: "nonexistent-tier"`. The server returns an error during challenge creation (`TIER_NOT_FOUND`). No payment is required and no challenge record is written.
+
+---
+
+### `idempotent-challenge.test.ts` — Idempotent Challenge (1 test)
+
+Verifies that the same `requestId` always returns the same `challengeId` within the TTL window.
+
+Calls `requestAccess` twice with identical `requestId`. Both responses return the same `challengeId`. The `agentgate:request:{requestId}` index key in Redis ensures the second call finds and returns the existing challenge instead of creating a new one.
+
+---
+
+### `token-issuance-failure.test.ts` — Token Issuance Failure (1 test)
+
+Verifies the critical invariant: **a PAID record stays PAID when the downstream token issuance fails.**
+
+Puts the backend into "fail" mode (`POST /test/set-mode`). Does a full payment — the gas wallet settles the on-chain USDC transfer successfully. The server calls `POST /internal/issue-token`, gets 500, and returns an error to the client. The challenge record in Redis is checked directly: it must be `PAID`, not rolled back to `PENDING` and not lost. This guarantees the refund cron can find and refund the payment.
+
+---
+
+### `refund-success.test.ts` — Refund Success (1 test)
+
+Verifies the refund cron picks up a PAID record and returns USDC to the original payer.
+
+Writes a PAID record directly into Redis via `writePaidChallengeRecord` (bypasses the full payment flow to avoid cost and latency). The record has `fromAddress = CLIENT_WALLET_ADDRESS`, `amountRaw = 10_000n` ($0.01 USDC), and `paidAt` set 10 seconds in the past — already past the 3-second `REFUND_MIN_AGE_MS`. The test polls `readChallengeState()` every second until it becomes `"REFUNDED"` (within 30 seconds).
+
+Internally, the cron:
+1. Queries the `agentgate:paid` sorted set for records older than `REFUND_MIN_AGE_MS`.
+2. Atomically transitions the record `PAID → REFUND_PENDING` (prevents double-refund across instances).
+3. Sends USDC back to `fromAddress` via EIP-3009 `transferWithAuthorization` — the gas wallet pays the gas.
+4. Transitions `REFUND_PENDING → REFUNDED` with the `refundTxHash`.
+
+USDC cost per run: ~$0.01.
+
+---
+
+### `refund-failure.test.ts` — Refund Failure (1 test)
+
+Verifies that when the AGENTGATE wallet has 0 USDC, the refund fails gracefully — the record transitions to `REFUND_FAILED` rather than being stuck in `REFUND_PENDING` indefinitely.
+
+Uses a **separate Docker stack** (`docker-compose.e2e-refund-fail.yml`) where `AGENTGATE_WALLET_PRIVATE_KEY` is set to a deterministic unfunded key (`0x...1234`) — an address that has never held USDC on any testnet. Writes a PAID record to that stack's Redis. The cron runs, attempts `transferWithAuthorization`, the USDC contract reverts (insufficient balance), the exception is caught, and the record transitions to `REFUND_FAILED`.
+
+---
+
+### `concurrent-purchases.test.ts` — Concurrent Purchases (1 test)
+
+Verifies that two clients purchasing simultaneously both succeed with distinct grants — no race condition on the gas wallet nonce.
+
+Fires `purchaseAccess()` from two `E2eTestClient` instances (CLIENT and GAS wallets) simultaneously via `Promise.all`. Both payments arrive at the server at the same time. The server serializes the two gas wallet settlement calls using a Redis distributed lock (`agentgate:settle-lock:{walletPrefix}` with SET NX) — preventing both from reading the same pending nonce. Both settle successfully, return distinct `AccessGrant`s with distinct `txHash`es, and both challenge records end up in `DELIVERED` state.
+
+---
+
+## Infrastructure Notes
+
+**Refund cron timings** (configured in `docker-compose.e2e.yml` for speed):
+- `REFUND_INTERVAL_MS=5000` — cron fires every 5 seconds
+- `REFUND_MIN_AGE_MS=3000` — records must be at least 3 seconds old to be eligible
+- `REFUND_POLL_TIMEOUT_MS=30_000` — test polls for up to 30 seconds
+
+**Redis port:** Docker Redis is mapped to `localhost:6380` (not 6379) to avoid conflict with any locally running Redis.
+
+**Gas wallet settlement lock:** When Redis is available, concurrent `settleViaGasWallet` calls are serialized via a Redis lock (`agentgate:settle-lock:{prefix}`, TTL 60s) — safe across multiple instances. Without Redis, falls back to an in-process promise queue (single instance only).
+
+**Sorted set atomicity:** The `agentgate:paid` sorted set is updated inside the same Lua script as the state transition — both the hash write and the ZADD/ZREM are atomic. A process crash cannot leave a PAID record outside the sorted set where the refund cron would never find it.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,10 +19,10 @@ Test Process (Bun)
   │     ← Tests read/write state directly via ioredis for setup and assertions
   │
   └── E2eTestClient (viem, EIP-3009)
-        1. POST /a2a/access (no payment)     → HTTP 402 + challengeId
-        2. signTypedData(TransferWithAuth)   → off-chain EIP-3009 signature
-        3. POST /a2a/access (payment-signature header) → gas wallet settles → AccessGrant (JWT)
-        4. GET  /api/resource/:id (Bearer)   → protected backend API
+        1. POST /x402/access (no payment)     → HTTP 402 + challengeId
+        2. signTypedData(TransferWithAuth)    → off-chain EIP-3009 signature
+        3. POST /x402/access (payment-signature header) → gas wallet settles → AccessGrant (JWT)
+        4. GET  /api/resource/:id (Bearer)    → protected backend API
 ```
 
 ## Prerequisites
@@ -77,9 +77,9 @@ No wallet or on-chain interaction needed.
 The full purchase flow where everything works correctly.
 
 **Main test (purchase → JWT → protected API):**
-1. `POST /a2a/access` with no payment → server returns HTTP 402 with `challengeId` and payment requirements in a base64-encoded `payment-required` header.
+1. `POST /x402/access` with no payment → server returns HTTP 402 with `challengeId` and payment requirements in a base64-encoded `payment-required` header.
 2. Client signs an EIP-3009 `TransferWithAuthorization` off-chain — authorizes the gas wallet to move USDC from the client's address to the AgentGate wallet.
-3. `POST /a2a/access` with `payment-signature` header containing the EIP-3009 signature → gas wallet executes the on-chain transfer → server issues an `AccessGrant` (JWT).
+3. `POST /x402/access` with `payment-signature` header containing the EIP-3009 signature → gas wallet executes the on-chain transfer → server issues an `AccessGrant` (JWT).
 4. `GET /api/resource/resource-1` with `Authorization: Bearer <jwt>` → backend returns 200 with resource data.
 
 **Also tests:**
@@ -120,11 +120,31 @@ Signs an EIP-3009 authorization with the `to` field set to a random address inst
 
 ---
 
-### `invalid-tier.test.ts` — Invalid Tier (1 test)
+### `invalid-tier.test.ts` — Invalid Tier (2 tests)
 
-Verifies that requesting an unknown tier fails immediately — before any payment requirements are issued.
+Verifies tier validation on `POST /x402/access`.
 
-Calls `requestAccess` with `tierId: "nonexistent-tier"`. The server returns an error during challenge creation (`TIER_NOT_FOUND`). No payment is required and no challenge record is written.
+- **Nonexistent tierId**: returns `400 TIER_NOT_FOUND` — challenge creation fails before any PENDING record is written.
+- **Missing tierId**: returns `402` discovery response with all available tiers — this is the discovery mode (no PENDING record, just a list of tiers to choose from).
+
+---
+
+### `x402-discovery.test.ts` — x402 Discovery (3 tests)
+
+Verifies the discovery flow: `POST /x402/access` with no `tierId`.
+
+The `/x402/access` endpoint has three modes:
+1. **No tierId** → discovery 402: returns all tiers in the `accepts` array with `tierId` in each tier's `extra`. No PENDING record is created. Also validates the `payment-required` header, `www-authenticate` header, and `agentgate` extensions (inputSchema, outputSchema).
+2. **tierId, no signature** → challenge 402 (covered by happy-path)
+3. **tierId + signature** → settle and grant (covered by happy-path)
+
+---
+
+### `expired-authorization.test.ts` — Expired Authorization (1 test)
+
+Verifies that an EIP-3009 authorization with a `validBefore` timestamp in the past is rejected.
+
+Signs a `TransferWithAuthorization` with `validBeforeOverride: 1n` (Unix epoch + 1 second — far in the past). The settlement layer's `verify()` checks `block.timestamp <= validBefore` and rejects the authorization before any on-chain call. No gas is spent.
 
 ---
 

--- a/e2e/docker-compose.e2e-refund-fail.yml
+++ b/e2e/docker-compose.e2e-refund-fail.yml
@@ -1,0 +1,42 @@
+# Separate stack for refund-failure.test.ts: empty AGENTGATE wallet (0 USDC).
+# The refund cron will attempt to send USDC but fail because the wallet is empty.
+services:
+  agentgate-refund-fail:
+    build: ..
+    ports:
+      - "3020:3020"
+    environment:
+      PORT: 3020
+      AGENTGATE_WALLET_ADDRESS: ${AGENTGATE_WALLET_ADDRESS}
+      # Empty wallet: deterministic test-only private key, never funded with USDC.
+      # Address: derived from this key (has 0 USDC on any testnet).
+      AGENTGATE_WALLET_PRIVATE_KEY: "0x0000000000000000000000000000000000000000000000000000000000001234"
+      GAS_WALLET_PRIVATE_KEY: ${GAS_WALLET_PRIVATE_KEY}
+      ISSUE_TOKEN_API: http://host.docker.internal:3001/internal/issue-token
+      AGENTGATE_NETWORK: testnet
+      REDIS_URL: redis://redis-refund-fail:6379
+      REFUND_INTERVAL_MS: 5000
+      REFUND_MIN_AGE_MS: 3000
+      CHALLENGE_TTL_SECONDS: 30
+      AGENT_URL: http://localhost:3020
+      BASE_PATH: /a2a
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      redis-refund-fail:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3020/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis-refund-fail:
+    image: redis:7-alpine
+    ports:
+      - "6381:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 5

--- a/e2e/docker-compose.e2e-short-ttl.yml
+++ b/e2e/docker-compose.e2e-short-ttl.yml
@@ -1,0 +1,36 @@
+# Separate stack for challenge-timeout.test.ts: short TTL, different ports.
+services:
+  agentgate-short-ttl:
+    build: ..
+    ports:
+      - "3010:3010"
+    environment:
+      PORT: 3010
+      AGENTGATE_WALLET_ADDRESS: ${AGENTGATE_WALLET_ADDRESS}
+      GAS_WALLET_PRIVATE_KEY: ${GAS_WALLET_PRIVATE_KEY}
+      ISSUE_TOKEN_API: http://host.docker.internal:3001/internal/issue-token
+      AGENTGATE_NETWORK: testnet
+      REDIS_URL: redis://redis-short-ttl:6379
+      CHALLENGE_TTL_SECONDS: ${E2E_SHORT_CHALLENGE_TTL:-5}
+      AGENT_URL: http://localhost:3010
+      BASE_PATH: /a2a
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      redis-short-ttl:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3010/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis-short-ttl:
+    image: redis:7-alpine
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 5

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -1,0 +1,38 @@
+services:
+  agentgate:
+    build: ..
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: 3000
+      AGENTGATE_WALLET_ADDRESS: ${AGENTGATE_WALLET_ADDRESS}
+      AGENTGATE_WALLET_PRIVATE_KEY: ${AGENTGATE_WALLET_KEY}
+      GAS_WALLET_PRIVATE_KEY: ${GAS_WALLET_PRIVATE_KEY}
+      ISSUE_TOKEN_API: http://host.docker.internal:3001/internal/issue-token
+      AGENTGATE_NETWORK: testnet
+      REDIS_URL: redis://redis:6379
+      REFUND_INTERVAL_MS: 5000
+      REFUND_MIN_AGE_MS: 3000
+      CHALLENGE_TTL_SECONDS: 300
+      AGENT_URL: http://localhost:3000
+      BASE_PATH: /a2a
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 5

--- a/e2e/fixtures/constants.ts
+++ b/e2e/fixtures/constants.ts
@@ -1,0 +1,23 @@
+/** Shared constants for e2e tests. */
+
+export const AGENTGATE_URL = "http://localhost:3000";
+export const BACKEND_URL = "http://localhost:3001";
+
+// Base Sepolia testnet
+export const CHAIN_ID = 84532;
+export const USDC_ADDRESS = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as `0x${string}`;
+export const USDC_DOMAIN = { name: "USDC", version: "2" } as const;
+
+/** Default tier configured in the Docker server's PRODUCTS env */
+export const DEFAULT_TIER_ID = "basic";
+export const DEFAULT_TIER_AMOUNT_MICRO = 100_000n; // $0.10 USDC
+
+/** Refund-fail stack constants (refund-failure.test.ts) */
+export const REFUND_FAIL_AGENTGATE_URL = "http://localhost:3020";
+export const REFUND_FAIL_REDIS_URL = "redis://localhost:6381";
+
+/** Refund cron timing (matches docker-compose.e2e.yml) */
+export const REFUND_INTERVAL_MS = 5000;
+export const REFUND_MIN_AGE_MS = 3000;
+/** Poll timeout for refund assertions: interval + min age + buffer */
+export const REFUND_POLL_TIMEOUT_MS = 30_000;

--- a/e2e/fixtures/wallets.ts
+++ b/e2e/fixtures/wallets.ts
@@ -1,0 +1,74 @@
+/**
+ * Load test wallets from environment variables and create viem clients.
+ */
+
+import { type PublicClient, http, createPublicClient, createWalletClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+import { E2eTestClient } from "../helpers/client.ts";
+import {
+	AGENTGATE_URL,
+	CHAIN_ID,
+	USDC_ADDRESS,
+	USDC_DOMAIN,
+} from "./constants.ts";
+
+function requireEnv(name: string): string {
+	const val = process.env[name];
+	if (!val) throw new Error(`Missing required env var: ${name}`);
+	return val;
+}
+
+function optionalEnv(name: string): string | undefined {
+	return process.env[name];
+}
+
+/** Primary test wallet (CLIENT) — signs EIP-3009 authorizations / sends payments */
+export function makeClientWallet() {
+	const privateKey = requireEnv("CLIENT_WALLET_PRIVATE_KEY") as `0x${string}`;
+	const rpcUrl = optionalEnv("ALCHEMY_BASE_SEPOLIA_RPC_URL") ?? "https://sepolia.base.org";
+
+	const account = privateKeyToAccount(privateKey);
+	const transport = http(rpcUrl);
+
+	const walletClient = createWalletClient({ chain: baseSepolia, transport, account });
+	const publicClient = createPublicClient({ chain: baseSepolia, transport });
+
+	return { account, walletClient, publicClient };
+}
+
+/** Secondary wallet (GAS) — second concurrent buyer in concurrent-purchases.test.ts */
+export function makeGasWallet() {
+	const privateKey = requireEnv("GAS_WALLET_PRIVATE_KEY") as `0x${string}`;
+	const rpcUrl = optionalEnv("ALCHEMY_BASE_SEPOLIA_RPC_URL") ?? "https://sepolia.base.org";
+
+	const account = privateKeyToAccount(privateKey);
+	const transport = http(rpcUrl);
+
+	const walletClient = createWalletClient({ chain: baseSepolia, transport, account });
+	const publicClient = createPublicClient({ chain: baseSepolia, transport });
+
+	return { account, walletClient, publicClient };
+}
+
+/** Create an E2eTestClient for the primary CLIENT wallet. */
+export function makeClientE2eClient(agentgateUrl = AGENTGATE_URL): E2eTestClient {
+	const { walletClient, publicClient } = makeClientWallet();
+	return new E2eTestClient(agentgateUrl, walletClient, publicClient as unknown as PublicClient, USDC_ADDRESS, CHAIN_ID, USDC_DOMAIN);
+}
+
+/** Create an E2eTestClient for the GAS wallet (secondary buyer). */
+export function makeGasE2eClient(agentgateUrl = AGENTGATE_URL): E2eTestClient {
+	const { walletClient, publicClient } = makeGasWallet();
+	return new E2eTestClient(agentgateUrl, walletClient, publicClient as unknown as PublicClient, USDC_ADDRESS, CHAIN_ID, USDC_DOMAIN);
+}
+
+/** AGENTGATE_WALLET_ADDRESS — for assertions (e.g. destination address in challenges). */
+export function agentgateWalletAddress(): `0x${string}` {
+	return requireEnv("AGENTGATE_WALLET_ADDRESS") as `0x${string}`;
+}
+
+/** CLIENT_WALLET_ADDRESS — for assertions (e.g. refund recipient). */
+export function clientWalletAddress(): `0x${string}` {
+	return requireEnv("CLIENT_WALLET_ADDRESS") as `0x${string}`;
+}

--- a/e2e/fixtures/wallets.ts
+++ b/e2e/fixtures/wallets.ts
@@ -2,16 +2,11 @@
  * Load test wallets from environment variables and create viem clients.
  */
 
-import { type PublicClient, http, createPublicClient, createWalletClient } from "viem";
+import { createPublicClient, createWalletClient, http, type PublicClient } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 import { E2eTestClient } from "../helpers/client.ts";
-import {
-	AGENTGATE_URL,
-	CHAIN_ID,
-	USDC_ADDRESS,
-	USDC_DOMAIN,
-} from "./constants.ts";
+import { AGENTGATE_URL, CHAIN_ID, USDC_ADDRESS, USDC_DOMAIN } from "./constants.ts";
 
 function requireEnv(name: string): string {
 	const val = process.env[name];
@@ -54,13 +49,27 @@ export function makeGasWallet() {
 /** Create an E2eTestClient for the primary CLIENT wallet. */
 export function makeClientE2eClient(agentgateUrl = AGENTGATE_URL): E2eTestClient {
 	const { walletClient, publicClient } = makeClientWallet();
-	return new E2eTestClient(agentgateUrl, walletClient, publicClient as unknown as PublicClient, USDC_ADDRESS, CHAIN_ID, USDC_DOMAIN);
+	return new E2eTestClient(
+		agentgateUrl,
+		walletClient,
+		publicClient as unknown as PublicClient,
+		USDC_ADDRESS,
+		CHAIN_ID,
+		USDC_DOMAIN,
+	);
 }
 
 /** Create an E2eTestClient for the GAS wallet (secondary buyer). */
 export function makeGasE2eClient(agentgateUrl = AGENTGATE_URL): E2eTestClient {
 	const { walletClient, publicClient } = makeGasWallet();
-	return new E2eTestClient(agentgateUrl, walletClient, publicClient as unknown as PublicClient, USDC_ADDRESS, CHAIN_ID, USDC_DOMAIN);
+	return new E2eTestClient(
+		agentgateUrl,
+		walletClient,
+		publicClient as unknown as PublicClient,
+		USDC_ADDRESS,
+		CHAIN_ID,
+		USDC_DOMAIN,
+	);
 }
 
 /** AGENTGATE_WALLET_ADDRESS — for assertions (e.g. destination address in challenges). */

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,58 @@
+/**
+ * Global e2e setup — loaded via `bun test --preload ./global-setup.ts`.
+ *
+ * Starts (once per test run):
+ *   1. Backend server (port 3001) — in-process Express
+ *   2. Docker stack (AgentGate port 3000 + Redis port 6379) — via docker compose
+ *
+ * Tears down both in afterAll.
+ *
+ * Note: challenge-timeout.test.ts and refund-failure.test.ts each manage their
+ * own separate docker stacks in their own beforeAll/afterAll.
+ */
+
+import { afterAll, beforeAll } from "bun:test";
+import type { Server } from "http";
+import { startBackend } from "./helpers/backend-server.ts";
+import { printLogs, startDockerStack, stopDockerStack } from "./helpers/docker-manager.ts";
+import { connectRedis, disconnectRedis } from "./helpers/redis-client.ts";
+import { AGENTGATE_URL } from "./fixtures/constants.ts";
+
+let backendServer: Server | null = null;
+
+beforeAll(async () => {
+	// 1. Start the backend
+	backendServer = await startBackend();
+
+	// 2. Start the Docker stack (builds image + waits for health)
+	try {
+		startDockerStack();
+	} catch (err) {
+		console.error("[setup] Docker stack failed to start:", err);
+		printLogs();
+		throw err;
+	}
+
+	// 3. Verify AgentGate is reachable
+	const healthRes = await fetch(`${AGENTGATE_URL}/health`);
+	if (!healthRes.ok) {
+		throw new Error(`AgentGate health check failed: ${healthRes.status}`);
+	}
+	console.log("[setup] AgentGate health:", await healthRes.json());
+
+	// 4. Connect Redis client for assertions
+	connectRedis();
+
+	console.log("[setup] Ready.");
+});
+
+afterAll(async () => {
+	await disconnectRedis();
+
+	if (backendServer) {
+		await new Promise<void>((resolve) => backendServer!.close(() => resolve()));
+		backendServer = null;
+	}
+
+	stopDockerStack();
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -12,11 +12,11 @@
  */
 
 import { afterAll, beforeAll } from "bun:test";
-import type { Server } from "http";
+import type { Server } from "node:http";
+import { AGENTGATE_URL } from "./fixtures/constants.ts";
 import { startBackend } from "./helpers/backend-server.ts";
 import { printLogs, startDockerStack, stopDockerStack } from "./helpers/docker-manager.ts";
 import { connectRedis, disconnectRedis } from "./helpers/redis-client.ts";
-import { AGENTGATE_URL } from "./fixtures/constants.ts";
 
 let backendServer: Server | null = null;
 

--- a/e2e/helpers/backend-server.ts
+++ b/e2e/helpers/backend-server.ts
@@ -1,0 +1,85 @@
+/**
+ * Controllable backend server for e2e tests.
+ *
+ * Endpoints:
+ *   POST /internal/issue-token   ← AgentGate Docker calls this after payment
+ *   POST /test/set-mode          ← Tests switch between "success" / "fail"
+ *   GET  /api/resource/:id       ← Protected resource, validates Bearer JWT
+ */
+
+import express from "express";
+import { SignJWT, jwtVerify } from "jose";
+import type { Server } from "http";
+
+export const BACKEND_PORT = 3001;
+export const BACKEND_JWT_SECRET = "e2e-backend-jwt-secret-for-testing-1234567890";
+
+const secretBytes = new TextEncoder().encode(BACKEND_JWT_SECRET);
+
+let mode: "success" | "fail" = "success";
+
+export function startBackend(): Promise<Server> {
+	const app = express();
+	app.use(express.json());
+
+	// ── Token issuance ──────────────────────────────────────────────────────
+	app.post("/internal/issue-token", async (req, res) => {
+		if (mode === "fail") {
+			res.status(500).json({ error: "Backend down" });
+			return;
+		}
+
+		const { challengeId, requestId, resourceId, tierId, txHash } = req.body as Record<
+			string,
+			string
+		>;
+
+		const token = await new SignJWT({ challengeId, requestId, resourceId, tierId, txHash })
+			.setProtectedHeader({ alg: "HS256" })
+			.setIssuedAt()
+			.setExpirationTime("1h")
+			.sign(secretBytes);
+
+		const expiresAt = new Date(Date.now() + 3600 * 1000).toISOString();
+		res.json({ token, expiresAt, tokenType: "Bearer" });
+	});
+
+	// ── Mode control ────────────────────────────────────────────────────────
+	app.post("/test/set-mode", (req, res) => {
+		const { mode: newMode } = req.body as { mode: "success" | "fail" };
+		if (newMode !== "success" && newMode !== "fail") {
+			res.status(400).json({ error: "mode must be 'success' or 'fail'" });
+			return;
+		}
+		mode = newMode;
+		res.status(204).send();
+	});
+
+	// ── Protected resource ──────────────────────────────────────────────────
+	app.get("/api/resource/:id", async (req, res) => {
+		const authHeader = req.headers.authorization;
+		if (!authHeader?.startsWith("Bearer ")) {
+			res.status(401).json({ error: "Missing Bearer token" });
+			return;
+		}
+
+		const token = authHeader.slice(7);
+		try {
+			const { payload } = await jwtVerify(token, secretBytes);
+			res.json({ data: "resource content", resourceId: req.params["id"], tokenSub: payload.sub });
+		} catch {
+			res.status(401).json({ error: "Invalid or expired token" });
+		}
+	});
+
+	return new Promise((resolve) => {
+		const server = app.listen(BACKEND_PORT, () => {
+			console.log(`[e2e backend] Listening on port ${BACKEND_PORT}`);
+			resolve(server);
+		});
+	});
+}
+
+export function resetMode(): void {
+	mode = "success";
+}

--- a/e2e/helpers/backend-server.ts
+++ b/e2e/helpers/backend-server.ts
@@ -7,9 +7,9 @@
  *   GET  /api/resource/:id       ← Protected resource, validates Bearer JWT
  */
 
+import type { Server } from "node:http";
 import express from "express";
-import { SignJWT, jwtVerify } from "jose";
-import type { Server } from "http";
+import { jwtVerify, SignJWT } from "jose";
 
 export const BACKEND_PORT = 3001;
 export const BACKEND_JWT_SECRET = "e2e-backend-jwt-secret-for-testing-1234567890";

--- a/e2e/helpers/client.ts
+++ b/e2e/helpers/client.ts
@@ -1,0 +1,309 @@
+/**
+ * E2eTestClient: drives the AgentGate Docker payment flow.
+ *
+ * Payment flow (EIP-3009 off-chain authorization, gas wallet settlement):
+ *   1. POST /a2a/access                    → HTTP 402 with challengeId + payment requirements
+ *   2. signTypedData(TransferWithAuth)      → EIP-3009 off-chain authorization signature
+ *   3. POST /a2a/access + PAYMENT-SIGNATURE → gas wallet executes transfer, returns AccessGrant
+ *   4. GET  /api/resource/:id (Bearer)      → call protected backend API
+ */
+
+import { randomBytes } from "crypto";
+import { type PublicClient, type WalletClient, formatUnits } from "viem";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export type AgentCard = {
+	name: string;
+	description: string;
+	url: string;
+	skills: Array<{
+		id: string;
+		name?: string;
+		pricing?: Array<{
+			tierId: string;
+			label: string;
+			amount: string;
+			chainId: number;
+		}>;
+	}>;
+	capabilities: {
+		extensions?: Array<{ uri: string; required?: boolean }>;
+	};
+};
+
+export type ChallengeResponse = {
+	challengeId: string;
+	paymentRequired: {
+		x402Version: number;
+		accepts: Array<{
+			scheme: string;
+			network: string;
+			asset: string;
+			amount: string;
+			payTo: string;
+			maxTimeoutSeconds: number;
+			extra?: Record<string, unknown>;
+		}>;
+	};
+};
+
+export type AccessGrant = {
+	type: "AccessGrant";
+	challengeId: string;
+	requestId: string;
+	accessToken: string;
+	tokenType: "Bearer";
+	expiresAt: string;
+	resourceEndpoint: string;
+	resourceId: string;
+	tierId: string;
+	txHash: `0x${string}`;
+	explorerUrl: string;
+};
+
+export type EIP3009Auth = {
+	signature: `0x${string}`;
+	authorization: {
+		from: string;
+		to: string;
+		value: string;
+		validAfter: string;
+		validBefore: string;
+		nonce: `0x${string}`;
+	};
+};
+
+// ─── EIP-3009 typed data ────────────────────────────────────────────────────
+
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+	TransferWithAuthorization: [
+		{ name: "from", type: "address" },
+		{ name: "to", type: "address" },
+		{ name: "value", type: "uint256" },
+		{ name: "validAfter", type: "uint256" },
+		{ name: "validBefore", type: "uint256" },
+		{ name: "nonce", type: "bytes32" },
+	],
+} as const;
+
+// ─── E2eTestClient ──────────────────────────────────────────────────────────
+
+export class E2eTestClient {
+	constructor(
+		private readonly agentgateUrl: string,
+		private readonly walletClient: WalletClient,
+		private readonly publicClient: PublicClient,
+		private readonly usdcAddress: `0x${string}`,
+		private readonly chainId: number,
+		private readonly usdcDomain: { name: string; version: string },
+	) {}
+
+	get account(): `0x${string}` {
+		const acc = this.walletClient.account;
+		if (!acc) throw new Error("WalletClient has no account");
+		return acc.address;
+	}
+
+	// ── Step 1: Request access ────────────────────────────────────────────
+
+	async requestAccess(opts: {
+		tierId: string;
+		requestId: string;
+		resourceId?: string;
+	}): Promise<ChallengeResponse> {
+		const res = await fetch(`${this.agentgateUrl}/a2a/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				tierId: opts.tierId,
+				requestId: opts.requestId,
+				resourceId: opts.resourceId ?? "default",
+				clientAgentId: `agent://${this.account}`,
+			}),
+		});
+
+		if (res.status !== 402) {
+			const text = await res.text();
+			throw new Error(`Expected HTTP 402, got ${res.status}: ${text}`);
+		}
+
+		const body = (await res.json()) as Record<string, unknown>;
+		const challengeId = body["challengeId"] as string;
+
+		// Decode PAYMENT-REQUIRED header
+		const header = res.headers.get("payment-required");
+		if (!header) throw new Error("Missing PAYMENT-REQUIRED header");
+		const paymentRequired = JSON.parse(
+			Buffer.from(header, "base64").toString("utf-8"),
+		) as ChallengeResponse["paymentRequired"];
+
+		return { challengeId, paymentRequired };
+	}
+
+	// ── Step 2: Sign EIP-3009 authorization ──────────────────────────────
+
+	async signEIP3009(opts: {
+		destination: `0x${string}`;
+		/** Amount in token micro-units (e.g., 100000n for $0.10 USDC) */
+		amountRaw: bigint;
+		/** Override validBefore (seconds). Defaults to now + 300s */
+		validBeforeOverride?: bigint;
+	}): Promise<EIP3009Auth> {
+		const nonce = `0x${randomBytes(32).toString("hex")}` as `0x${string}`;
+		const validAfter = 0n;
+		const validBefore = opts.validBeforeOverride ?? BigInt(Math.floor(Date.now() / 1000) + 300);
+
+		const signature = await this.walletClient.signTypedData({
+			account: this.walletClient.account!,
+			domain: {
+				name: this.usdcDomain.name,
+				version: this.usdcDomain.version,
+				chainId: this.chainId,
+				verifyingContract: this.usdcAddress,
+			},
+			types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+			primaryType: "TransferWithAuthorization",
+			message: {
+				from: this.account,
+				to: opts.destination,
+				value: opts.amountRaw,
+				validAfter,
+				validBefore,
+				nonce,
+			},
+		});
+
+		return {
+			signature,
+			authorization: {
+				from: this.account,
+				to: opts.destination,
+				value: opts.amountRaw.toString(),
+				validAfter: validAfter.toString(),
+				validBefore: validBefore.toString(),
+				nonce,
+			},
+		};
+	}
+
+	// ── Step 3: Submit payment ────────────────────────────────────────────
+
+	async submitPayment(opts: {
+		tierId: string;
+		requestId: string;
+		resourceId?: string;
+		auth: EIP3009Auth;
+		paymentRequired: ChallengeResponse["paymentRequired"];
+	}): Promise<{ grant?: AccessGrant; error?: Record<string, unknown>; status: number }> {
+		const requirements = opts.paymentRequired.accepts[0];
+		if (!requirements) throw new Error("No accepted payment requirements");
+
+		const paymentPayload = {
+			x402Version: 2,
+			network: `eip155:${this.chainId}`,
+			scheme: "exact",
+			payload: {
+				signature: opts.auth.signature,
+				authorization: opts.auth.authorization,
+				from: this.account,
+			},
+			accepted: requirements,
+		};
+
+		const paymentSignature = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
+
+		const res = await fetch(`${this.agentgateUrl}/a2a/access`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"payment-signature": paymentSignature,
+			},
+			body: JSON.stringify({
+				tierId: opts.tierId,
+				requestId: opts.requestId,
+				resourceId: opts.resourceId ?? "default",
+				clientAgentId: `agent://${this.account}`,
+			}),
+		});
+
+		const body = await res.json();
+		if (res.ok) {
+			return { grant: body as AccessGrant, status: res.status };
+		}
+		return { error: body as Record<string, unknown>, status: res.status };
+	}
+
+	// ── Convenience: full purchase ────────────────────────────────────────
+
+	async purchaseAccess(opts: {
+		tierId: string;
+		requestId?: string;
+		resourceId?: string;
+	}): Promise<{
+		requestId: string;
+		challengeId: string;
+		grant: AccessGrant;
+	}> {
+		const requestId = opts.requestId ?? crypto.randomUUID();
+		const { challengeId, paymentRequired } = await this.requestAccess({
+			tierId: opts.tierId,
+			requestId,
+			...(opts.resourceId !== undefined ? { resourceId: opts.resourceId } : {}),
+		});
+
+		const requirements = paymentRequired.accepts[0];
+		if (!requirements) throw new Error("No payment requirements");
+		const amountRaw = BigInt(requirements.amount);
+		const destination = requirements.payTo as `0x${string}`;
+
+		const auth = await this.signEIP3009({ destination, amountRaw });
+
+		const result = await this.submitPayment({
+			tierId: opts.tierId,
+			requestId,
+			...(opts.resourceId !== undefined ? { resourceId: opts.resourceId } : {}),
+			auth,
+			paymentRequired,
+		});
+
+		if (!result.grant) {
+			throw new Error(`Payment failed: ${JSON.stringify(result.error)}`);
+		}
+
+		return { requestId, challengeId, grant: result.grant };
+	}
+
+	// ── Agent card ────────────────────────────────────────────────────────
+
+	async fetchAgentCard(): Promise<AgentCard> {
+		const res = await fetch(`${this.agentgateUrl}/.well-known/agent.json`);
+		if (!res.ok) throw new Error(`Failed to fetch agent card: ${res.status}`);
+		return res.json() as Promise<AgentCard>;
+	}
+
+	// ── USDC balance ──────────────────────────────────────────────────────
+
+	async getUsdcBalance(): Promise<bigint> {
+		const BALANCE_OF_ABI = [
+			{
+				type: "function",
+				name: "balanceOf",
+				inputs: [{ name: "account", type: "address" }],
+				outputs: [{ name: "", type: "uint256" }],
+				stateMutability: "view",
+			},
+		] as const;
+
+		return this.publicClient.readContract({
+			address: this.usdcAddress,
+			abi: BALANCE_OF_ABI,
+			functionName: "balanceOf",
+			args: [this.account],
+		}) as Promise<bigint>;
+	}
+
+	getUsdcBalanceFormatted(): Promise<string> {
+		return this.getUsdcBalance().then((b) => formatUnits(b, 6));
+	}
+}

--- a/e2e/helpers/client.ts
+++ b/e2e/helpers/client.ts
@@ -8,8 +8,8 @@
  *   4. GET  /api/resource/:id (Bearer)        → call protected backend API
  */
 
-import { randomBytes } from "crypto";
-import { type PublicClient, type WalletClient, formatUnits } from "viem";
+import { randomBytes } from "node:crypto";
+import { formatUnits, type PublicClient, type WalletClient } from "viem";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -236,11 +236,7 @@ export class E2eTestClient {
 
 	// ── Convenience: full purchase ────────────────────────────────────────
 
-	async purchaseAccess(opts: {
-		tierId: string;
-		requestId?: string;
-		resourceId?: string;
-	}): Promise<{
+	async purchaseAccess(opts: { tierId: string; requestId?: string; resourceId?: string }): Promise<{
 		requestId: string;
 		challengeId: string;
 		grant: AccessGrant;

--- a/e2e/helpers/client.ts
+++ b/e2e/helpers/client.ts
@@ -2,10 +2,10 @@
  * E2eTestClient: drives the AgentGate Docker payment flow.
  *
  * Payment flow (EIP-3009 off-chain authorization, gas wallet settlement):
- *   1. POST /a2a/access                    → HTTP 402 with challengeId + payment requirements
- *   2. signTypedData(TransferWithAuth)      → EIP-3009 off-chain authorization signature
- *   3. POST /a2a/access + PAYMENT-SIGNATURE → gas wallet executes transfer, returns AccessGrant
- *   4. GET  /api/resource/:id (Bearer)      → call protected backend API
+ *   1. POST /x402/access                     → HTTP 402 with challengeId + payment requirements
+ *   2. signTypedData(TransferWithAuth)        → EIP-3009 off-chain authorization signature
+ *   3. POST /x402/access + PAYMENT-SIGNATURE → gas wallet executes transfer, returns AccessGrant
+ *   4. GET  /api/resource/:id (Bearer)        → call protected backend API
  */
 
 import { randomBytes } from "crypto";
@@ -112,7 +112,7 @@ export class E2eTestClient {
 		requestId: string;
 		resourceId?: string;
 	}): Promise<ChallengeResponse> {
-		const res = await fetch(`${this.agentgateUrl}/a2a/access`, {
+		const res = await fetch(`${this.agentgateUrl}/x402/access`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -213,7 +213,7 @@ export class E2eTestClient {
 
 		const paymentSignature = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
 
-		const res = await fetch(`${this.agentgateUrl}/a2a/access`, {
+		const res = await fetch(`${this.agentgateUrl}/x402/access`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/e2e/helpers/docker-manager.ts
+++ b/e2e/helpers/docker-manager.ts
@@ -1,0 +1,62 @@
+/**
+ * Manages docker compose lifecycle for e2e tests.
+ */
+
+import { execSync, spawnSync } from "child_process";
+import path from "path";
+
+const E2E_DIR = path.resolve(import.meta.dir, "..");
+
+export type StackConfig = {
+	composeFile?: string;
+	projectName?: string;
+	/** milliseconds to wait for health before giving up (default: 60_000) */
+	healthTimeoutMs?: number;
+};
+
+function compose(args: string, config: StackConfig): void {
+	const file = config.composeFile ?? "docker-compose.e2e.yml";
+	const project = config.projectName ?? "agentgate-e2e";
+	const cmd = `docker compose -f ${file} -p ${project} ${args}`;
+	execSync(cmd, { cwd: E2E_DIR, stdio: "inherit", env: { ...process.env } });
+}
+
+export function startDockerStack(config: StackConfig = {}): void {
+	console.log("[docker] Starting stack...");
+	compose("up -d --build --wait", config);
+	console.log("[docker] Stack healthy.");
+}
+
+export function stopDockerStack(config: StackConfig = {}): void {
+	console.log("[docker] Stopping stack...");
+	compose("down -v", config);
+	console.log("[docker] Stack stopped.");
+}
+
+/** Wait for an HTTP endpoint to return 2xx. */
+export async function waitForHttp(url: string, timeoutMs = 60_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(url);
+			if (res.ok) return;
+		} catch {
+			// not ready yet
+		}
+		await Bun.sleep(1000);
+	}
+	throw new Error(`Timed out waiting for ${url}`);
+}
+
+/** Print recent docker compose logs (for debugging on failure). */
+export function printLogs(config: StackConfig = {}): void {
+	const file = config.composeFile ?? "docker-compose.e2e.yml";
+	const project = config.projectName ?? "agentgate-e2e";
+	const result = spawnSync(
+		"docker",
+		["compose", "-f", file, "-p", project, "logs", "--tail=100"],
+		{ cwd: E2E_DIR, encoding: "utf8", env: { ...process.env } },
+	);
+	console.log(result.stdout);
+	console.error(result.stderr);
+}

--- a/e2e/helpers/docker-manager.ts
+++ b/e2e/helpers/docker-manager.ts
@@ -2,8 +2,8 @@
  * Manages docker compose lifecycle for e2e tests.
  */
 
-import { execSync, spawnSync } from "child_process";
-import path from "path";
+import { execSync, spawnSync } from "node:child_process";
+import path from "node:path";
 
 const E2E_DIR = path.resolve(import.meta.dir, "..");
 
@@ -52,11 +52,11 @@ export async function waitForHttp(url: string, timeoutMs = 60_000): Promise<void
 export function printLogs(config: StackConfig = {}): void {
 	const file = config.composeFile ?? "docker-compose.e2e.yml";
 	const project = config.projectName ?? "agentgate-e2e";
-	const result = spawnSync(
-		"docker",
-		["compose", "-f", file, "-p", project, "logs", "--tail=100"],
-		{ cwd: E2E_DIR, encoding: "utf8", env: { ...process.env } },
-	);
+	const result = spawnSync("docker", ["compose", "-f", file, "-p", project, "logs", "--tail=100"], {
+		cwd: E2E_DIR,
+		encoding: "utf8",
+		env: { ...process.env },
+	});
 	console.log(result.stdout);
 	console.error(result.stderr);
 }

--- a/e2e/helpers/redis-client.ts
+++ b/e2e/helpers/redis-client.ts
@@ -1,0 +1,92 @@
+/**
+ * Redis client helpers for e2e test assertions.
+ * Reads and writes challenge state directly for fast assertions.
+ */
+
+import Redis from "ioredis";
+
+export const REDIS_URL = "redis://localhost:6380";
+const KEY_PREFIX = "agentgate";
+
+let client: Redis | null = null;
+
+export function connectRedis(url = REDIS_URL): Redis {
+	if (client) return client;
+	client = new Redis(url, { lazyConnect: true });
+	return client;
+}
+
+export async function disconnectRedis(): Promise<void> {
+	if (client) {
+		await client.quit();
+		client = null;
+	}
+}
+
+/** Read the state field of a challenge record from Redis. */
+export async function readChallengeState(
+	challengeId: string,
+	redis = connectRedis(),
+): Promise<string | null> {
+	return redis.hget(`${KEY_PREFIX}:challenge:${challengeId}`, "state");
+}
+
+/** Read the full challenge record from Redis. */
+export async function readChallengeRecord(
+	challengeId: string,
+	redis = connectRedis(),
+): Promise<Record<string, string> | null> {
+	const flat = await redis.hgetall(`${KEY_PREFIX}:challenge:${challengeId}`);
+	if (!flat["challengeId"]) return null;
+	return flat;
+}
+
+/**
+ * Write a PAID challenge record directly to Redis.
+ * Used by refund tests to set up test state without going through the full payment flow.
+ */
+export async function writePaidChallengeRecord(
+	record: {
+		challengeId: string;
+		requestId: string;
+		clientAgentId: string;
+		resourceId: string;
+		tierId: string;
+		amount: string;
+		amountRaw: bigint;
+		destination: `0x${string}`;
+		fromAddress: `0x${string}`;
+		txHash: `0x${string}`;
+		paidAt: Date;
+	},
+	redis = connectRedis(),
+): Promise<void> {
+	const key = `${KEY_PREFIX}:challenge:${record.challengeId}`;
+	const paidSetKey = `${KEY_PREFIX}:paid`;
+
+	const flat: Record<string, string> = {
+		challengeId: record.challengeId,
+		requestId: record.requestId,
+		clientAgentId: record.clientAgentId,
+		resourceId: record.resourceId,
+		tierId: record.tierId,
+		amount: record.amount,
+		amountRaw: record.amountRaw.toString(),
+		asset: "USDC",
+		chainId: "84532",
+		destination: record.destination,
+		state: "PAID",
+		expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+		createdAt: new Date(Date.now() - 60_000).toISOString(),
+		paidAt: record.paidAt.toISOString(),
+		txHash: record.txHash,
+		fromAddress: record.fromAddress,
+	};
+
+	const pipeline = redis.pipeline();
+	pipeline.hset(key, flat);
+	pipeline.expire(key, 604_800); // 7 days
+	// Add to paid sorted set (score = paidAt epoch ms, for refund cron eligibility)
+	pipeline.zadd(paidSetKey, record.paidAt.getTime(), record.challengeId);
+	await pipeline.exec();
+}

--- a/e2e/helpers/wait.ts
+++ b/e2e/helpers/wait.ts
@@ -1,0 +1,30 @@
+/**
+ * Polling utilities for async assertions.
+ */
+
+/** Poll fn until it returns a truthy value or timeout is exceeded. */
+export async function pollUntil<T>(
+	fn: () => Promise<T | null | undefined | false>,
+	timeoutMs: number,
+	intervalMs = 1000,
+): Promise<T> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const result = await fn();
+		if (result) return result;
+		await Bun.sleep(intervalMs);
+	}
+	throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
+}
+
+/** Poll until challengeState === expected, return the state. */
+export async function waitForChallengeState(
+	readState: () => Promise<string | null>,
+	expectedState: string,
+	timeoutMs: number,
+): Promise<string> {
+	return pollUntil(async () => {
+		const s = await readState();
+		return s === expectedState ? s : null;
+	}, timeoutMs);
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "agentgate-e2e",
+	"version": "0.0.1",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"test": "bun test --preload ./global-setup.ts --timeout 60000",
+		"test:card": "bun test scenarios/agent-card.test.ts --timeout 30000",
+		"test:happy": "bun test scenarios/happy-path.test.ts --timeout 120000"
+	},
+	"dependencies": {
+		"express": "^4.21.0",
+		"ioredis": "^5.0.0",
+		"jose": "^6.0.0",
+		"viem": "^2.21.0"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.3.9",
+		"@types/express": "^5.0.0"
+	}
+}

--- a/e2e/scenarios/a2a-jsonrpc-x402.test.ts
+++ b/e2e/scenarios/a2a-jsonrpc-x402.test.ts
@@ -1,0 +1,194 @@
+/**
+ * A2A JSON-RPC x402 Middleware — verifies the x402 payment flow on /a2a/jsonrpc.
+ *
+ * The x402-http-middleware intercepts POST /a2a/jsonrpc when:
+ *   - X-A2A-Extensions header is ABSENT (non-A2A client)
+ *   - method === "message/send"
+ *   - params.message.parts contains a part with type === "AccessRequest"
+ *
+ * Two-step flow:
+ *   1. POST /a2a/jsonrpc + AccessRequest (no PAYMENT-SIGNATURE) → 402 + challengeId
+ *   2. POST /a2a/jsonrpc + AccessRequest + PAYMENT-SIGNATURE → settle → 200 AccessGrant
+ *
+ * This is the code path used by non-MCP HTTP clients that POST JSON-RPC directly
+ * rather than using the /x402/access simple HTTP endpoint.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AGENTGATE_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import type { AccessGrant } from "../helpers/client.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+const JSONRPC_URL = `${AGENTGATE_URL}/a2a/jsonrpc`;
+
+/** Build a JSON-RPC message/send body with an AccessRequest data part */
+function buildJsonRpcRequest(
+	tierId: string,
+	requestId: string,
+	resourceId = "default",
+): Record<string, unknown> {
+	return {
+		jsonrpc: "2.0",
+		id: "1",
+		method: "message/send",
+		params: {
+			message: {
+				parts: [
+					{
+						kind: "data",
+						data: {
+							type: "AccessRequest",
+							requestId,
+							tierId,
+							resourceId,
+							clientAgentId: "agent://e2e-test",
+						},
+					},
+				],
+			},
+		},
+	};
+}
+
+describe("A2A JSON-RPC x402 Middleware", () => {
+	test("POST /a2a/jsonrpc with AccessRequest (no signature) returns 402 + challengeId", async () => {
+		const requestId = crypto.randomUUID();
+
+		const res = await fetch(JSONRPC_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			// No X-A2A-Extensions header → middleware intercepts
+			body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
+		});
+
+		expect(res.status).toBe(402);
+
+		const body = (await res.json()) as Record<string, unknown>;
+
+		// Middleware returns challengeId + payment requirements inline
+		expect(typeof body["challengeId"]).toBe("string");
+		expect((body["challengeId"] as string).length).toBeGreaterThan(0);
+		expect(body["error"]).toBe("PAYMENT-SIGNATURE header is required");
+		expect(Array.isArray(body["accepts"])).toBe(true);
+
+		// payment-required header must be set
+		const header = res.headers.get("payment-required");
+		expect(header).toBeTruthy();
+		const decoded = JSON.parse(Buffer.from(header!, "base64").toString("utf-8"));
+		expect(decoded.x402Version).toBe(2);
+		expect(decoded.accepts[0].scheme).toBe("exact");
+	});
+
+	test(
+		"POST /a2a/jsonrpc with AccessRequest + PAYMENT-SIGNATURE returns 200 AccessGrant",
+		async () => {
+			const client = makeClientE2eClient();
+			const requestId = crypto.randomUUID();
+
+			// Step 1: Get challenge (no signature)
+			const challengeRes = await fetch(JSONRPC_URL, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
+			});
+
+			expect(challengeRes.status).toBe(402);
+			const challengeBody = (await challengeRes.json()) as Record<string, unknown>;
+			const challengeId = challengeBody["challengeId"] as string;
+
+			// Decode payment requirements from header
+			const header = challengeRes.headers.get("payment-required");
+			expect(header).toBeTruthy();
+			const paymentRequired = JSON.parse(
+				Buffer.from(header!, "base64").toString("utf-8"),
+			) as { accepts: Array<{ amount: string; payTo: string }> };
+
+			const requirements = paymentRequired.accepts[0]!;
+
+			// Step 2: Sign EIP-3009
+			const auth = await client.signEIP3009({
+				destination: requirements.payTo as `0x${string}`,
+				amountRaw: BigInt(requirements.amount),
+			});
+
+			// Build PAYMENT-SIGNATURE payload (same format as /x402/access)
+			const paymentPayload = {
+				x402Version: 2,
+				network: `eip155:84532`,
+				scheme: "exact",
+				payload: {
+					signature: auth.signature,
+					authorization: auth.authorization,
+					from: client.account,
+				},
+				accepted: requirements,
+			};
+			const paymentSignature = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
+
+			// Step 3: POST with signature
+			const settleRes = await fetch(JSONRPC_URL, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"payment-signature": paymentSignature,
+				},
+				body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
+			});
+
+			expect(settleRes.status).toBe(200);
+
+			const grant = (await settleRes.json()) as AccessGrant;
+			expect(grant.type).toBe("AccessGrant");
+			expect(typeof grant.accessToken).toBe("string");
+			expect(grant.tokenType).toBe("Bearer");
+			expect(grant.txHash).toMatch(/^0x/);
+			expect(grant.challengeId).toBe(challengeId);
+			expect(grant.requestId).toBe(requestId);
+
+			// payment-response header must be set
+			const paymentResponse = settleRes.headers.get("payment-response");
+			expect(paymentResponse).toBeTruthy();
+		},
+		120_000,
+	);
+
+	test("POST /a2a/jsonrpc with X-A2A-Extensions header passes through to A2A handler", async () => {
+		// When X-A2A-Extensions is present, the middleware skips x402 logic and
+		// passes the request to the A2A JSON-RPC handler. The A2A handler processes
+		// the request normally (not as a payment flow).
+		// Since the request doesn't match a valid A2A task, it returns an A2A error response —
+		// NOT a 402. This confirms the middleware correctly detected the header and passed through.
+		const res = await fetch(JSONRPC_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-a2a-extensions": "x402/v2", // presence alone triggers passthrough
+			},
+			body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, crypto.randomUUID())),
+		});
+
+		// Not 402 — the middleware did NOT intercept this request
+		expect(res.status).not.toBe(402);
+	});
+
+	test("POST /a2a/jsonrpc without AccessRequest in parts passes through to A2A handler", async () => {
+		// message/send with non-AccessRequest parts → middleware passes through
+		const res = await fetch(JSONRPC_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: "1",
+				method: "message/send",
+				params: {
+					message: {
+						parts: [{ kind: "text", text: "Hello, not an access request" }],
+					},
+				},
+			}),
+		});
+
+		// Passes through — not intercepted as x402 — not 402
+		expect(res.status).not.toBe(402);
+	});
+});

--- a/e2e/scenarios/a2a-jsonrpc-x402.test.ts
+++ b/e2e/scenarios/a2a-jsonrpc-x402.test.ts
@@ -16,8 +16,8 @@
 
 import { describe, expect, test } from "bun:test";
 import { AGENTGATE_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
-import type { AccessGrant } from "../helpers/client.ts";
 import { makeClientE2eClient } from "../fixtures/wallets.ts";
+import type { AccessGrant } from "../helpers/client.ts";
 
 const JSONRPC_URL = `${AGENTGATE_URL}/a2a/jsonrpc`;
 
@@ -79,78 +79,74 @@ describe("A2A JSON-RPC x402 Middleware", () => {
 		expect(decoded.accepts[0].scheme).toBe("exact");
 	});
 
-	test(
-		"POST /a2a/jsonrpc with AccessRequest + PAYMENT-SIGNATURE returns 200 AccessGrant",
-		async () => {
-			const client = makeClientE2eClient();
-			const requestId = crypto.randomUUID();
+	test("POST /a2a/jsonrpc with AccessRequest + PAYMENT-SIGNATURE returns 200 AccessGrant", async () => {
+		const client = makeClientE2eClient();
+		const requestId = crypto.randomUUID();
 
-			// Step 1: Get challenge (no signature)
-			const challengeRes = await fetch(JSONRPC_URL, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
-			});
+		// Step 1: Get challenge (no signature)
+		const challengeRes = await fetch(JSONRPC_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
+		});
 
-			expect(challengeRes.status).toBe(402);
-			const challengeBody = (await challengeRes.json()) as Record<string, unknown>;
-			const challengeId = challengeBody["challengeId"] as string;
+		expect(challengeRes.status).toBe(402);
+		const challengeBody = (await challengeRes.json()) as Record<string, unknown>;
+		const challengeId = challengeBody["challengeId"] as string;
 
-			// Decode payment requirements from header
-			const header = challengeRes.headers.get("payment-required");
-			expect(header).toBeTruthy();
-			const paymentRequired = JSON.parse(
-				Buffer.from(header!, "base64").toString("utf-8"),
-			) as { accepts: Array<{ amount: string; payTo: string }> };
+		// Decode payment requirements from header
+		const header = challengeRes.headers.get("payment-required");
+		expect(header).toBeTruthy();
+		const paymentRequired = JSON.parse(Buffer.from(header!, "base64").toString("utf-8")) as {
+			accepts: Array<{ amount: string; payTo: string }>;
+		};
 
-			const requirements = paymentRequired.accepts[0]!;
+		const requirements = paymentRequired.accepts[0]!;
 
-			// Step 2: Sign EIP-3009
-			const auth = await client.signEIP3009({
-				destination: requirements.payTo as `0x${string}`,
-				amountRaw: BigInt(requirements.amount),
-			});
+		// Step 2: Sign EIP-3009
+		const auth = await client.signEIP3009({
+			destination: requirements.payTo as `0x${string}`,
+			amountRaw: BigInt(requirements.amount),
+		});
 
-			// Build PAYMENT-SIGNATURE payload (same format as /x402/access)
-			const paymentPayload = {
-				x402Version: 2,
-				network: `eip155:84532`,
-				scheme: "exact",
-				payload: {
-					signature: auth.signature,
-					authorization: auth.authorization,
-					from: client.account,
-				},
-				accepted: requirements,
-			};
-			const paymentSignature = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
+		// Build PAYMENT-SIGNATURE payload (same format as /x402/access)
+		const paymentPayload = {
+			x402Version: 2,
+			network: `eip155:84532`,
+			scheme: "exact",
+			payload: {
+				signature: auth.signature,
+				authorization: auth.authorization,
+				from: client.account,
+			},
+			accepted: requirements,
+		};
+		const paymentSignature = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
 
-			// Step 3: POST with signature
-			const settleRes = await fetch(JSONRPC_URL, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					"payment-signature": paymentSignature,
-				},
-				body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
-			});
+		// Step 3: POST with signature
+		const settleRes = await fetch(JSONRPC_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"payment-signature": paymentSignature,
+			},
+			body: JSON.stringify(buildJsonRpcRequest(DEFAULT_TIER_ID, requestId)),
+		});
 
-			expect(settleRes.status).toBe(200);
+		expect(settleRes.status).toBe(200);
 
-			const grant = (await settleRes.json()) as AccessGrant;
-			expect(grant.type).toBe("AccessGrant");
-			expect(typeof grant.accessToken).toBe("string");
-			expect(grant.tokenType).toBe("Bearer");
-			expect(grant.txHash).toMatch(/^0x/);
-			expect(grant.challengeId).toBe(challengeId);
-			expect(grant.requestId).toBe(requestId);
+		const grant = (await settleRes.json()) as AccessGrant;
+		expect(grant.type).toBe("AccessGrant");
+		expect(typeof grant.accessToken).toBe("string");
+		expect(grant.tokenType).toBe("Bearer");
+		expect(grant.txHash).toMatch(/^0x/);
+		expect(grant.challengeId).toBe(challengeId);
+		expect(grant.requestId).toBe(requestId);
 
-			// payment-response header must be set
-			const paymentResponse = settleRes.headers.get("payment-response");
-			expect(paymentResponse).toBeTruthy();
-		},
-		120_000,
-	);
+		// payment-response header must be set
+		const paymentResponse = settleRes.headers.get("payment-response");
+		expect(paymentResponse).toBeTruthy();
+	}, 120_000);
 
 	test("POST /a2a/jsonrpc with X-A2A-Extensions header passes through to A2A handler", async () => {
 		// When X-A2A-Extensions is present, the middleware skips x402 logic and

--- a/e2e/scenarios/agent-card.test.ts
+++ b/e2e/scenarios/agent-card.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { AGENTGATE_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import type { AgentCard } from "../helpers/client.ts";
+
+describe("Agent Card", () => {
+	test("GET /.well-known/agent.json returns valid agent card", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/.well-known/agent.json`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("application/json");
+
+		const card = (await res.json()) as AgentCard;
+
+		expect(typeof card.name).toBe("string");
+		expect(card.name.length).toBeGreaterThan(0);
+		expect(typeof card.description).toBe("string");
+		expect(typeof card.url).toBe("string");
+
+		// Must have skills
+		expect(Array.isArray(card.skills)).toBe(true);
+		expect(card.skills.length).toBeGreaterThan(0);
+
+		// Must have a "request-access" skill
+		const requestSkill = card.skills.find((s) => s.id === DEFAULT_TIER_ID);
+		expect(requestSkill).toBeDefined();
+		expect(Array.isArray(requestSkill?.pricing)).toBe(true);
+		expect((requestSkill?.pricing?.length ?? 0)).toBeGreaterThan(0);
+
+		// x402 extension must be declared
+		expect(Array.isArray(card.capabilities.extensions)).toBe(true);
+		const x402ext = card.capabilities.extensions?.find((e) => e.uri.includes("x402"));
+		expect(x402ext).toBeDefined();
+		expect(x402ext?.required).toBe(true);
+	});
+
+	test("Agent card pricing includes USDC on Base Sepolia", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/.well-known/agent.json`);
+		const card = (await res.json()) as AgentCard;
+
+		const skill = card.skills.find((s) => s.id === DEFAULT_TIER_ID);
+		const tier = skill?.pricing?.[0];
+		expect(tier).toBeDefined();
+		expect(typeof tier?.amount).toBe("string");
+		// Amount should be a dollar string
+		expect(tier?.amount).toMatch(/^\$/);
+		expect(tier?.chainId).toBe(84532); // Base Sepolia
+	});
+});

--- a/e2e/scenarios/agent-card.test.ts
+++ b/e2e/scenarios/agent-card.test.ts
@@ -23,7 +23,7 @@ describe("Agent Card", () => {
 		const requestSkill = card.skills.find((s) => s.id === DEFAULT_TIER_ID);
 		expect(requestSkill).toBeDefined();
 		expect(Array.isArray(requestSkill?.pricing)).toBe(true);
-		expect((requestSkill?.pricing?.length ?? 0)).toBeGreaterThan(0);
+		expect(requestSkill?.pricing?.length ?? 0).toBeGreaterThan(0);
 
 		// x402 extension must be declared
 		expect(Array.isArray(card.capabilities.extensions)).toBe(true);

--- a/e2e/scenarios/challenge-timeout.test.ts
+++ b/e2e/scenarios/challenge-timeout.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Challenge Timeout — verifies that once the requestId index key expires,
+ * the same requestId creates a NEW challenge (idempotency resets after TTL).
+ *
+ * Simulates TTL expiry by deleting `agentgate:request:{requestId}` directly
+ * from Redis, avoiding the need for a separate short-TTL Docker stack.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+import { connectRedis } from "../helpers/redis-client.ts";
+
+describe("Challenge Timeout", () => {
+	test(
+		"same requestId creates a new challenge after TTL expires (simulated via Redis key deletion)",
+		async () => {
+			const client = makeClientE2eClient();
+			const redis = connectRedis();
+			const requestId = crypto.randomUUID();
+
+			// Step 1: Get first challenge
+			const first = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+			const challengeId1 = first.challengeId;
+			expect(typeof challengeId1).toBe("string");
+			expect(challengeId1.length).toBeGreaterThan(0);
+
+			// Simulate TTL expiry: delete the requestId→challengeId index key
+			const deleted = await redis.del(`agentgate:request:${requestId}`);
+			expect(deleted).toBe(1);
+
+			// Step 2: Same requestId → should create a NEW challenge (index key gone)
+			const second = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+			const challengeId2 = second.challengeId;
+			expect(typeof challengeId2).toBe("string");
+			expect(challengeId2).not.toBe(challengeId1);
+		},
+		30_000,
+	);
+});

--- a/e2e/scenarios/challenge-timeout.test.ts
+++ b/e2e/scenarios/challenge-timeout.test.ts
@@ -12,29 +12,25 @@ import { makeClientE2eClient } from "../fixtures/wallets.ts";
 import { connectRedis } from "../helpers/redis-client.ts";
 
 describe("Challenge Timeout", () => {
-	test(
-		"same requestId creates a new challenge after TTL expires (simulated via Redis key deletion)",
-		async () => {
-			const client = makeClientE2eClient();
-			const redis = connectRedis();
-			const requestId = crypto.randomUUID();
+	test("same requestId creates a new challenge after TTL expires (simulated via Redis key deletion)", async () => {
+		const client = makeClientE2eClient();
+		const redis = connectRedis();
+		const requestId = crypto.randomUUID();
 
-			// Step 1: Get first challenge
-			const first = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
-			const challengeId1 = first.challengeId;
-			expect(typeof challengeId1).toBe("string");
-			expect(challengeId1.length).toBeGreaterThan(0);
+		// Step 1: Get first challenge
+		const first = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+		const challengeId1 = first.challengeId;
+		expect(typeof challengeId1).toBe("string");
+		expect(challengeId1.length).toBeGreaterThan(0);
 
-			// Simulate TTL expiry: delete the requestId→challengeId index key
-			const deleted = await redis.del(`agentgate:request:${requestId}`);
-			expect(deleted).toBe(1);
+		// Simulate TTL expiry: delete the requestId→challengeId index key
+		const deleted = await redis.del(`agentgate:request:${requestId}`);
+		expect(deleted).toBe(1);
 
-			// Step 2: Same requestId → should create a NEW challenge (index key gone)
-			const second = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
-			const challengeId2 = second.challengeId;
-			expect(typeof challengeId2).toBe("string");
-			expect(challengeId2).not.toBe(challengeId1);
-		},
-		30_000,
-	);
+		// Step 2: Same requestId → should create a NEW challenge (index key gone)
+		const second = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+		const challengeId2 = second.challengeId;
+		expect(typeof challengeId2).toBe("string");
+		expect(challengeId2).not.toBe(challengeId1);
+	}, 30_000);
 });

--- a/e2e/scenarios/concurrent-purchases.test.ts
+++ b/e2e/scenarios/concurrent-purchases.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Concurrent Purchases — two clients buying simultaneously.
+ *
+ * Uses CLIENT and GAS wallets as two independent buyers.
+ * Both complete the full purchase flow in parallel.
+ * Asserts: distinct grants, distinct txHashes, both in DELIVERED state in Redis.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient, makeGasE2eClient } from "../fixtures/wallets.ts";
+import { readChallengeRecord } from "../helpers/redis-client.ts";
+
+describe("Concurrent Purchases", () => {
+	test(
+		"two clients purchasing simultaneously both receive distinct grants",
+		async () => {
+			const clientA = makeClientE2eClient();
+			const clientB = makeGasE2eClient();
+
+			const [resultA, resultB] = await Promise.all([
+				clientA.purchaseAccess({ tierId: DEFAULT_TIER_ID }),
+				clientB.purchaseAccess({ tierId: DEFAULT_TIER_ID }),
+			]);
+
+			// Both must succeed
+			expect(resultA.grant.type).toBe("AccessGrant");
+			expect(resultB.grant.type).toBe("AccessGrant");
+
+			// Grants must be distinct
+			expect(resultA.grant.challengeId).not.toBe(resultB.grant.challengeId);
+			expect(resultA.grant.txHash).not.toBe(resultB.grant.txHash);
+			expect(resultA.grant.accessToken).not.toBe(resultB.grant.accessToken);
+
+			// Both challenges must be in DELIVERED state
+			const [recordA, recordB] = await Promise.all([
+				readChallengeRecord(resultA.challengeId),
+				readChallengeRecord(resultB.challengeId),
+			]);
+
+			expect(recordA?.["state"]).toBe("DELIVERED");
+			expect(recordB?.["state"]).toBe("DELIVERED");
+		},
+		120_000,
+	);
+});

--- a/e2e/scenarios/concurrent-purchases.test.ts
+++ b/e2e/scenarios/concurrent-purchases.test.ts
@@ -12,35 +12,31 @@ import { makeClientE2eClient, makeGasE2eClient } from "../fixtures/wallets.ts";
 import { readChallengeRecord } from "../helpers/redis-client.ts";
 
 describe("Concurrent Purchases", () => {
-	test(
-		"two clients purchasing simultaneously both receive distinct grants",
-		async () => {
-			const clientA = makeClientE2eClient();
-			const clientB = makeGasE2eClient();
+	test("two clients purchasing simultaneously both receive distinct grants", async () => {
+		const clientA = makeClientE2eClient();
+		const clientB = makeGasE2eClient();
 
-			const [resultA, resultB] = await Promise.all([
-				clientA.purchaseAccess({ tierId: DEFAULT_TIER_ID }),
-				clientB.purchaseAccess({ tierId: DEFAULT_TIER_ID }),
-			]);
+		const [resultA, resultB] = await Promise.all([
+			clientA.purchaseAccess({ tierId: DEFAULT_TIER_ID }),
+			clientB.purchaseAccess({ tierId: DEFAULT_TIER_ID }),
+		]);
 
-			// Both must succeed
-			expect(resultA.grant.type).toBe("AccessGrant");
-			expect(resultB.grant.type).toBe("AccessGrant");
+		// Both must succeed
+		expect(resultA.grant.type).toBe("AccessGrant");
+		expect(resultB.grant.type).toBe("AccessGrant");
 
-			// Grants must be distinct
-			expect(resultA.grant.challengeId).not.toBe(resultB.grant.challengeId);
-			expect(resultA.grant.txHash).not.toBe(resultB.grant.txHash);
-			expect(resultA.grant.accessToken).not.toBe(resultB.grant.accessToken);
+		// Grants must be distinct
+		expect(resultA.grant.challengeId).not.toBe(resultB.grant.challengeId);
+		expect(resultA.grant.txHash).not.toBe(resultB.grant.txHash);
+		expect(resultA.grant.accessToken).not.toBe(resultB.grant.accessToken);
 
-			// Both challenges must be in DELIVERED state
-			const [recordA, recordB] = await Promise.all([
-				readChallengeRecord(resultA.challengeId),
-				readChallengeRecord(resultB.challengeId),
-			]);
+		// Both challenges must be in DELIVERED state
+		const [recordA, recordB] = await Promise.all([
+			readChallengeRecord(resultA.challengeId),
+			readChallengeRecord(resultB.challengeId),
+		]);
 
-			expect(recordA?.["state"]).toBe("DELIVERED");
-			expect(recordB?.["state"]).toBe("DELIVERED");
-		},
-		120_000,
-	);
+		expect(recordA?.["state"]).toBe("DELIVERED");
+		expect(recordB?.["state"]).toBe("DELIVERED");
+	}, 120_000);
 });

--- a/e2e/scenarios/double-spend.test.ts
+++ b/e2e/scenarios/double-spend.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Double Spend — verifies TX_ALREADY_REDEEMED protection.
+ *
+ * Submits the same EIP-3009 authorization nonce to two different challenges.
+ * First purchase succeeds; second fails because:
+ *   - The on-chain nonce is burned (transferWithAuthorization reverts), OR
+ *   - The seenTxStore has the txHash (application-level guard).
+ *
+ * Either failure mode proves double-spend protection works.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+describe("Double Spend Protection", () => {
+	test(
+		"reused EIP-3009 nonce is rejected on the second challenge",
+		async () => {
+			const client = makeClientE2eClient();
+
+			// ── Challenge 1 ─────────────────────────────────────────────
+			const req1 = crypto.randomUUID();
+			const { paymentRequired: pr1 } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId: req1,
+			});
+
+			const requirements = pr1.accepts[0]!;
+			const amountRaw = BigInt(requirements.amount);
+			const destination = requirements.payTo as `0x${string}`;
+
+			// Sign authorization (nonce is embedded in auth)
+			const auth = await client.signEIP3009({ destination, amountRaw });
+
+			// Submit to challenge 1 — should succeed
+			const result1 = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId: req1,
+				auth,
+				paymentRequired: pr1,
+			});
+			expect(result1.status).toBe(200);
+			expect(result1.grant).toBeDefined();
+
+			// ── Challenge 2 ─────────────────────────────────────────────
+			const req2 = crypto.randomUUID();
+			const { paymentRequired: pr2 } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId: req2,
+			});
+
+			// Reuse the SAME auth (same nonce — already burned on-chain).
+			// Update accepted requirements to point to challenge 2's requirements.
+			const result2 = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId: req2,
+				auth, // same nonce → burned on-chain → transferWithAuthorization reverts
+				paymentRequired: pr2,
+			});
+
+			// Must fail (on-chain revert from burned nonce, or seenTxStore guard)
+			expect(result2.status).not.toBe(200);
+			expect(result2.error).toBeDefined();
+		},
+		120_000,
+	);
+});

--- a/e2e/scenarios/double-spend.test.ts
+++ b/e2e/scenarios/double-spend.test.ts
@@ -14,55 +14,51 @@ import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
 import { makeClientE2eClient } from "../fixtures/wallets.ts";
 
 describe("Double Spend Protection", () => {
-	test(
-		"reused EIP-3009 nonce is rejected on the second challenge",
-		async () => {
-			const client = makeClientE2eClient();
+	test("reused EIP-3009 nonce is rejected on the second challenge", async () => {
+		const client = makeClientE2eClient();
 
-			// ── Challenge 1 ─────────────────────────────────────────────
-			const req1 = crypto.randomUUID();
-			const { paymentRequired: pr1 } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId: req1,
-			});
+		// ── Challenge 1 ─────────────────────────────────────────────
+		const req1 = crypto.randomUUID();
+		const { paymentRequired: pr1 } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId: req1,
+		});
 
-			const requirements = pr1.accepts[0]!;
-			const amountRaw = BigInt(requirements.amount);
-			const destination = requirements.payTo as `0x${string}`;
+		const requirements = pr1.accepts[0]!;
+		const amountRaw = BigInt(requirements.amount);
+		const destination = requirements.payTo as `0x${string}`;
 
-			// Sign authorization (nonce is embedded in auth)
-			const auth = await client.signEIP3009({ destination, amountRaw });
+		// Sign authorization (nonce is embedded in auth)
+		const auth = await client.signEIP3009({ destination, amountRaw });
 
-			// Submit to challenge 1 — should succeed
-			const result1 = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId: req1,
-				auth,
-				paymentRequired: pr1,
-			});
-			expect(result1.status).toBe(200);
-			expect(result1.grant).toBeDefined();
+		// Submit to challenge 1 — should succeed
+		const result1 = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId: req1,
+			auth,
+			paymentRequired: pr1,
+		});
+		expect(result1.status).toBe(200);
+		expect(result1.grant).toBeDefined();
 
-			// ── Challenge 2 ─────────────────────────────────────────────
-			const req2 = crypto.randomUUID();
-			const { paymentRequired: pr2 } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId: req2,
-			});
+		// ── Challenge 2 ─────────────────────────────────────────────
+		const req2 = crypto.randomUUID();
+		const { paymentRequired: pr2 } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId: req2,
+		});
 
-			// Reuse the SAME auth (same nonce — already burned on-chain).
-			// Update accepted requirements to point to challenge 2's requirements.
-			const result2 = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId: req2,
-				auth, // same nonce → burned on-chain → transferWithAuthorization reverts
-				paymentRequired: pr2,
-			});
+		// Reuse the SAME auth (same nonce — already burned on-chain).
+		// Update accepted requirements to point to challenge 2's requirements.
+		const result2 = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId: req2,
+			auth, // same nonce → burned on-chain → transferWithAuthorization reverts
+			paymentRequired: pr2,
+		});
 
-			// Must fail (on-chain revert from burned nonce, or seenTxStore guard)
-			expect(result2.status).not.toBe(200);
-			expect(result2.error).toBeDefined();
-		},
-		120_000,
-	);
+		// Must fail (on-chain revert from burned nonce, or seenTxStore guard)
+		expect(result2.status).not.toBe(200);
+		expect(result2.error).toBeDefined();
+	}, 120_000);
 });

--- a/e2e/scenarios/expired-authorization.test.ts
+++ b/e2e/scenarios/expired-authorization.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Expired Authorization — verifies that an EIP-3009 authorization with a validBefore
+ * timestamp in the past is rejected by the settlement layer.
+ *
+ * ExactEvmScheme.verify() checks the authorization window:
+ *   - validAfter  <= block.timestamp <= validBefore
+ * If validBefore < now, the authorization is already expired → PAYMENT_FAILED.
+ * No on-chain gas is spent for the settlement call since verify() fails first.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+describe("Expired Authorization", () => {
+	test(
+		"EIP-3009 authorization with validBefore in the past is rejected",
+		async () => {
+			const client = makeClientE2eClient();
+			const requestId = crypto.randomUUID();
+
+			const { paymentRequired } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+			});
+
+			const requirements = paymentRequired.accepts[0]!;
+			const destination = requirements.payTo as `0x${string}`;
+			const amountRaw = BigInt(requirements.amount);
+
+			// Sign with validBefore = 1 (Unix epoch + 1 second = long in the past)
+			const auth = await client.signEIP3009({
+				destination,
+				amountRaw,
+				validBeforeOverride: 1n,
+			});
+
+			const result = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+				auth,
+				paymentRequired,
+			});
+
+			// Must be rejected — expired authorization window
+			expect(result.status).not.toBe(200);
+			expect(result.error).toBeDefined();
+		},
+		60_000,
+	);
+});

--- a/e2e/scenarios/expired-authorization.test.ts
+++ b/e2e/scenarios/expired-authorization.test.ts
@@ -13,39 +13,35 @@ import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
 import { makeClientE2eClient } from "../fixtures/wallets.ts";
 
 describe("Expired Authorization", () => {
-	test(
-		"EIP-3009 authorization with validBefore in the past is rejected",
-		async () => {
-			const client = makeClientE2eClient();
-			const requestId = crypto.randomUUID();
+	test("EIP-3009 authorization with validBefore in the past is rejected", async () => {
+		const client = makeClientE2eClient();
+		const requestId = crypto.randomUUID();
 
-			const { paymentRequired } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-			});
+		const { paymentRequired } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+		});
 
-			const requirements = paymentRequired.accepts[0]!;
-			const destination = requirements.payTo as `0x${string}`;
-			const amountRaw = BigInt(requirements.amount);
+		const requirements = paymentRequired.accepts[0]!;
+		const destination = requirements.payTo as `0x${string}`;
+		const amountRaw = BigInt(requirements.amount);
 
-			// Sign with validBefore = 1 (Unix epoch + 1 second = long in the past)
-			const auth = await client.signEIP3009({
-				destination,
-				amountRaw,
-				validBeforeOverride: 1n,
-			});
+		// Sign with validBefore = 1 (Unix epoch + 1 second = long in the past)
+		const auth = await client.signEIP3009({
+			destination,
+			amountRaw,
+			validBeforeOverride: 1n,
+		});
 
-			const result = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-				auth,
-				paymentRequired,
-			});
+		const result = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+			auth,
+			paymentRequired,
+		});
 
-			// Must be rejected — expired authorization window
-			expect(result.status).not.toBe(200);
-			expect(result.error).toBeDefined();
-		},
-		60_000,
-	);
+		// Must be rejected — expired authorization window
+		expect(result.status).not.toBe(200);
+		expect(result.error).toBeDefined();
+	}, 60_000);
 });

--- a/e2e/scenarios/happy-path.test.ts
+++ b/e2e/scenarios/happy-path.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { BACKEND_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+describe("Happy Path: full purchase → JWT → protected API", () => {
+	test(
+		"purchase access and call protected API with Bearer token",
+		async () => {
+			const client = makeClientE2eClient();
+
+			// Step 1: Request access → get challenge + payment requirements
+			const requestId = crypto.randomUUID();
+			const { challengeId, paymentRequired } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+				resourceId: "resource-1",
+			});
+
+			expect(typeof challengeId).toBe("string");
+			expect(challengeId.length).toBeGreaterThan(0);
+			expect(paymentRequired.x402Version).toBe(2);
+			expect(paymentRequired.accepts.length).toBeGreaterThan(0);
+
+			const requirements = paymentRequired.accepts[0]!;
+			expect(requirements.scheme).toBe("exact");
+			expect(requirements.network).toBe("eip155:84532");
+			expect(typeof requirements.payTo).toBe("string");
+			expect(BigInt(requirements.amount)).toBeGreaterThan(0n);
+
+			// Step 2: Sign EIP-3009 authorization
+			const auth = await client.signEIP3009({
+				destination: requirements.payTo as `0x${string}`,
+				amountRaw: BigInt(requirements.amount),
+			});
+
+			expect(typeof auth.signature).toBe("string");
+			expect(auth.authorization.from).toBe(client.account);
+
+			// Step 3: Submit payment → gas wallet settles, returns AccessGrant
+			const result = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+				resourceId: "resource-1",
+				auth,
+				paymentRequired,
+			});
+
+			expect(result.status).toBe(200);
+			expect(result.grant).toBeDefined();
+
+			const grant = result.grant!;
+			expect(grant.type).toBe("AccessGrant");
+			expect(typeof grant.accessToken).toBe("string");
+			expect(grant.tokenType).toBe("Bearer");
+			expect(typeof grant.txHash).toBe("string");
+			expect(grant.txHash).toMatch(/^0x/);
+			expect(grant.challengeId).toBe(challengeId);
+			expect(grant.requestId).toBe(requestId);
+
+			// Step 4: Call backend's protected API with Bearer token
+			const apiRes = await fetch(`${BACKEND_URL}/api/resource/resource-1`, {
+				headers: { Authorization: `Bearer ${grant.accessToken}` },
+			});
+
+			expect(apiRes.status).toBe(200);
+			const apiBody = (await apiRes.json()) as Record<string, unknown>;
+			expect(apiBody["data"]).toBe("resource content");
+			expect(apiBody["resourceId"]).toBe("resource-1");
+		},
+		120_000,
+	);
+
+	test(
+		"rejected request without token returns 401",
+		async () => {
+			const res = await fetch(`${BACKEND_URL}/api/resource/resource-1`);
+			expect(res.status).toBe(401);
+		},
+	);
+
+	test(
+		"invalid token returns 401",
+		async () => {
+			const res = await fetch(`${BACKEND_URL}/api/resource/resource-1`, {
+				headers: { Authorization: "Bearer invalid-jwt-token" },
+			});
+			expect(res.status).toBe(401);
+		},
+	);
+});

--- a/e2e/scenarios/happy-path.test.ts
+++ b/e2e/scenarios/happy-path.test.ts
@@ -3,88 +3,78 @@ import { BACKEND_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
 import { makeClientE2eClient } from "../fixtures/wallets.ts";
 
 describe("Happy Path: full purchase → JWT → protected API", () => {
-	test(
-		"purchase access and call protected API with Bearer token",
-		async () => {
-			const client = makeClientE2eClient();
+	test("purchase access and call protected API with Bearer token", async () => {
+		const client = makeClientE2eClient();
 
-			// Step 1: Request access → get challenge + payment requirements
-			const requestId = crypto.randomUUID();
-			const { challengeId, paymentRequired } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-				resourceId: "resource-1",
-			});
+		// Step 1: Request access → get challenge + payment requirements
+		const requestId = crypto.randomUUID();
+		const { challengeId, paymentRequired } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+			resourceId: "resource-1",
+		});
 
-			expect(typeof challengeId).toBe("string");
-			expect(challengeId.length).toBeGreaterThan(0);
-			expect(paymentRequired.x402Version).toBe(2);
-			expect(paymentRequired.accepts.length).toBeGreaterThan(0);
+		expect(typeof challengeId).toBe("string");
+		expect(challengeId.length).toBeGreaterThan(0);
+		expect(paymentRequired.x402Version).toBe(2);
+		expect(paymentRequired.accepts.length).toBeGreaterThan(0);
 
-			const requirements = paymentRequired.accepts[0]!;
-			expect(requirements.scheme).toBe("exact");
-			expect(requirements.network).toBe("eip155:84532");
-			expect(typeof requirements.payTo).toBe("string");
-			expect(BigInt(requirements.amount)).toBeGreaterThan(0n);
+		const requirements = paymentRequired.accepts[0]!;
+		expect(requirements.scheme).toBe("exact");
+		expect(requirements.network).toBe("eip155:84532");
+		expect(typeof requirements.payTo).toBe("string");
+		expect(BigInt(requirements.amount)).toBeGreaterThan(0n);
 
-			// Step 2: Sign EIP-3009 authorization
-			const auth = await client.signEIP3009({
-				destination: requirements.payTo as `0x${string}`,
-				amountRaw: BigInt(requirements.amount),
-			});
+		// Step 2: Sign EIP-3009 authorization
+		const auth = await client.signEIP3009({
+			destination: requirements.payTo as `0x${string}`,
+			amountRaw: BigInt(requirements.amount),
+		});
 
-			expect(typeof auth.signature).toBe("string");
-			expect(auth.authorization.from).toBe(client.account);
+		expect(typeof auth.signature).toBe("string");
+		expect(auth.authorization.from).toBe(client.account);
 
-			// Step 3: Submit payment → gas wallet settles, returns AccessGrant
-			const result = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-				resourceId: "resource-1",
-				auth,
-				paymentRequired,
-			});
+		// Step 3: Submit payment → gas wallet settles, returns AccessGrant
+		const result = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+			resourceId: "resource-1",
+			auth,
+			paymentRequired,
+		});
 
-			expect(result.status).toBe(200);
-			expect(result.grant).toBeDefined();
+		expect(result.status).toBe(200);
+		expect(result.grant).toBeDefined();
 
-			const grant = result.grant!;
-			expect(grant.type).toBe("AccessGrant");
-			expect(typeof grant.accessToken).toBe("string");
-			expect(grant.tokenType).toBe("Bearer");
-			expect(typeof grant.txHash).toBe("string");
-			expect(grant.txHash).toMatch(/^0x/);
-			expect(grant.challengeId).toBe(challengeId);
-			expect(grant.requestId).toBe(requestId);
+		const grant = result.grant!;
+		expect(grant.type).toBe("AccessGrant");
+		expect(typeof grant.accessToken).toBe("string");
+		expect(grant.tokenType).toBe("Bearer");
+		expect(typeof grant.txHash).toBe("string");
+		expect(grant.txHash).toMatch(/^0x/);
+		expect(grant.challengeId).toBe(challengeId);
+		expect(grant.requestId).toBe(requestId);
 
-			// Step 4: Call backend's protected API with Bearer token
-			const apiRes = await fetch(`${BACKEND_URL}/api/resource/resource-1`, {
-				headers: { Authorization: `Bearer ${grant.accessToken}` },
-			});
+		// Step 4: Call backend's protected API with Bearer token
+		const apiRes = await fetch(`${BACKEND_URL}/api/resource/resource-1`, {
+			headers: { Authorization: `Bearer ${grant.accessToken}` },
+		});
 
-			expect(apiRes.status).toBe(200);
-			const apiBody = (await apiRes.json()) as Record<string, unknown>;
-			expect(apiBody["data"]).toBe("resource content");
-			expect(apiBody["resourceId"]).toBe("resource-1");
-		},
-		120_000,
-	);
+		expect(apiRes.status).toBe(200);
+		const apiBody = (await apiRes.json()) as Record<string, unknown>;
+		expect(apiBody["data"]).toBe("resource content");
+		expect(apiBody["resourceId"]).toBe("resource-1");
+	}, 120_000);
 
-	test(
-		"rejected request without token returns 401",
-		async () => {
-			const res = await fetch(`${BACKEND_URL}/api/resource/resource-1`);
-			expect(res.status).toBe(401);
-		},
-	);
+	test("rejected request without token returns 401", async () => {
+		const res = await fetch(`${BACKEND_URL}/api/resource/resource-1`);
+		expect(res.status).toBe(401);
+	});
 
-	test(
-		"invalid token returns 401",
-		async () => {
-			const res = await fetch(`${BACKEND_URL}/api/resource/resource-1`, {
-				headers: { Authorization: "Bearer invalid-jwt-token" },
-			});
-			expect(res.status).toBe(401);
-		},
-	);
+	test("invalid token returns 401", async () => {
+		const res = await fetch(`${BACKEND_URL}/api/resource/resource-1`, {
+			headers: { Authorization: "Bearer invalid-jwt-token" },
+		});
+		expect(res.status).toBe(401);
+	});
 });

--- a/e2e/scenarios/idempotent-challenge.test.ts
+++ b/e2e/scenarios/idempotent-challenge.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Idempotent Challenge — same requestId returns the same challengeId.
+ *
+ * Verifies that repeated AccessRequests with the same requestId
+ * are deduplicated by the challenge engine.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+describe("Idempotent Challenge", () => {
+	test("same requestId returns same challengeId on repeated requests", async () => {
+		const client = makeClientE2eClient();
+		const requestId = crypto.randomUUID();
+
+		const first = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+		const second = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+		const third = await client.requestAccess({ tierId: DEFAULT_TIER_ID, requestId });
+
+		expect(first.challengeId).toBe(second.challengeId);
+		expect(second.challengeId).toBe(third.challengeId);
+
+		// Payment requirements must be identical
+		expect(first.paymentRequired.accepts[0]?.amount).toBe(
+			second.paymentRequired.accepts[0]?.amount,
+		);
+		expect(first.paymentRequired.accepts[0]?.payTo).toBe(
+			second.paymentRequired.accepts[0]?.payTo,
+		);
+	});
+
+	test("different requestIds create distinct challenges", async () => {
+		const client = makeClientE2eClient();
+
+		const first = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId: crypto.randomUUID(),
+		});
+		const second = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId: crypto.randomUUID(),
+		});
+
+		expect(first.challengeId).not.toBe(second.challengeId);
+	});
+});

--- a/e2e/scenarios/idempotent-challenge.test.ts
+++ b/e2e/scenarios/idempotent-challenge.test.ts
@@ -25,9 +25,7 @@ describe("Idempotent Challenge", () => {
 		expect(first.paymentRequired.accepts[0]?.amount).toBe(
 			second.paymentRequired.accepts[0]?.amount,
 		);
-		expect(first.paymentRequired.accepts[0]?.payTo).toBe(
-			second.paymentRequired.accepts[0]?.payTo,
-		);
+		expect(first.paymentRequired.accepts[0]?.payTo).toBe(second.paymentRequired.accepts[0]?.payTo);
 	});
 
 	test("different requestIds create distinct challenges", async () => {

--- a/e2e/scenarios/invalid-tier.test.ts
+++ b/e2e/scenarios/invalid-tier.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Invalid Tier — verifies that requesting a nonexistent tierId returns an error.
+ *
+ * The /a2a/access endpoint validates the tier before creating a challenge.
+ * No on-chain tx needed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AGENTGATE_URL } from "../fixtures/constants.ts";
+
+describe("Invalid Tier", () => {
+	test("nonexistent tierId returns 400 TIER_NOT_FOUND", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/a2a/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				tierId: "nonexistent-tier-xyz",
+				requestId: crypto.randomUUID(),
+				resourceId: "test-resource",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["code"]).toBe("TIER_NOT_FOUND");
+	});
+
+	test("missing tierId returns 400", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/a2a/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ requestId: crypto.randomUUID() }),
+		});
+
+		expect(res.status).toBe(400);
+	});
+});

--- a/e2e/scenarios/invalid-tier.test.ts
+++ b/e2e/scenarios/invalid-tier.test.ts
@@ -1,7 +1,7 @@
 /**
  * Invalid Tier — verifies that requesting a nonexistent tierId returns an error.
  *
- * The /a2a/access endpoint validates the tier before creating a challenge.
+ * The /x402/access endpoint validates the tier before creating a challenge.
  * No on-chain tx needed.
  */
 
@@ -10,7 +10,7 @@ import { AGENTGATE_URL } from "../fixtures/constants.ts";
 
 describe("Invalid Tier", () => {
 	test("nonexistent tierId returns 400 TIER_NOT_FOUND", async () => {
-		const res = await fetch(`${AGENTGATE_URL}/a2a/access`, {
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -25,13 +25,21 @@ describe("Invalid Tier", () => {
 		expect(body["code"]).toBe("TIER_NOT_FOUND");
 	});
 
-	test("missing tierId returns 400", async () => {
-		const res = await fetch(`${AGENTGATE_URL}/a2a/access`, {
+	test("missing tierId returns 402 discovery response with all tiers", async () => {
+		// POST /x402/access with no tierId triggers discovery mode:
+		// returns 402 with all available tiers (no PENDING record created)
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ requestId: crypto.randomUUID() }),
 		});
 
-		expect(res.status).toBe(400);
+		expect(res.status).toBe(402);
+		const body = (await res.json()) as Record<string, unknown>;
+		// Discovery response contains all tiers in accepts array
+		expect(Array.isArray(body["accepts"])).toBe(true);
+		expect((body["accepts"] as unknown[]).length).toBeGreaterThan(0);
+		// No challengeId — this is pure discovery, no PENDING record
+		expect(body["challengeId"]).toBeUndefined();
 	});
 });

--- a/e2e/scenarios/malformed-signature.test.ts
+++ b/e2e/scenarios/malformed-signature.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Malformed Signature — verifies that invalid PAYMENT-SIGNATURE headers are rejected.
+ *
+ * decodePaymentSignature() in src/integrations/settlement.ts:
+ *   1. Tries base64url decode → JSON.parse
+ *   2. Falls back to standard base64 → JSON.parse
+ *   3. If both fail → throws AgentGateError("INVALID_REQUEST", ..., 400)
+ *
+ * The /x402/access handler catches AgentGateError and returns the HTTP status
+ * from the error (400 in this case).
+ *
+ * No wallet needed — pure HTTP test.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AGENTGATE_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+
+describe("Malformed PAYMENT-SIGNATURE", () => {
+	test("completely invalid string returns 400 INVALID_REQUEST", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"payment-signature": "this-is-not-valid-base64-json!!!",
+			},
+			body: JSON.stringify({
+				tierId: DEFAULT_TIER_ID,
+				requestId: crypto.randomUUID(),
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["code"]).toBe("INVALID_REQUEST");
+	});
+
+	test("valid base64 of non-JSON content returns 400 INVALID_REQUEST", async () => {
+		// "hello world" is valid base64-decodable but not JSON
+		const nonJsonBase64 = Buffer.from("hello world — not json").toString("base64");
+
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"payment-signature": nonJsonBase64,
+			},
+			body: JSON.stringify({
+				tierId: DEFAULT_TIER_ID,
+				requestId: crypto.randomUUID(),
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["code"]).toBe("INVALID_REQUEST");
+	});
+
+	test("valid base64 of JSON but wrong structure still reaches settlement and fails", async () => {
+		// Valid JSON but missing required x402 fields → settlement layer rejects it
+		const badPayload = { foo: "bar", not: "a payment payload" };
+		const encoded = Buffer.from(JSON.stringify(badPayload)).toString("base64");
+
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"payment-signature": encoded,
+			},
+			body: JSON.stringify({
+				tierId: DEFAULT_TIER_ID,
+				requestId: crypto.randomUUID(),
+			}),
+		});
+
+		// Decoded successfully but settlement verify() fails → not 200
+		expect(res.status).not.toBe(200);
+	});
+});

--- a/e2e/scenarios/refund-failure.test.ts
+++ b/e2e/scenarios/refund-failure.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Refund Failure — verifies REFUND_FAILED state when the refund tx reverts.
+ *
+ * Uses a separate Docker stack (docker-compose.e2e-refund-fail.yml) that has
+ * AGENTGATE_WALLET_PRIVATE_KEY set to a deterministic empty wallet (0 USDC).
+ * The refund cron attempts to send USDC from that empty wallet → tx reverts →
+ * record transitions to REFUND_FAILED.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import Redis from "ioredis";
+import { REFUND_FAIL_REDIS_URL, REFUND_POLL_TIMEOUT_MS, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { agentgateWalletAddress, clientWalletAddress } from "../fixtures/wallets.ts";
+import { writePaidChallengeRecord } from "../helpers/redis-client.ts";
+import { printLogs, startDockerStack, stopDockerStack } from "../helpers/docker-manager.ts";
+import { waitForChallengeState } from "../helpers/wait.ts";
+
+const STACK_CONFIG = {
+	composeFile: "docker-compose.e2e-refund-fail.yml",
+	projectName: "agentgate-e2e-refund-fail",
+};
+
+let redis: Redis | null = null;
+
+beforeAll(async () => {
+	try {
+		startDockerStack(STACK_CONFIG);
+	} catch (err) {
+		console.error("[refund-fail] Docker stack failed:", err);
+		printLogs(STACK_CONFIG);
+		throw err;
+	}
+
+	redis = new Redis(REFUND_FAIL_REDIS_URL);
+});
+
+afterAll(async () => {
+	await redis?.quit();
+	stopDockerStack(STACK_CONFIG);
+});
+
+describe("Refund Failure", () => {
+	test(
+		"PAID record transitions to REFUND_FAILED when agentgate wallet has 0 USDC",
+		async () => {
+			if (!redis) throw new Error("Redis not connected");
+
+			const challengeId = `e2e-refund-fail-${crypto.randomUUID()}`;
+			const clientAddr = clientWalletAddress();
+			const agentgateAddr = agentgateWalletAddress();
+
+			// Write PAID record to the refund-fail Redis instance
+			const paidAt = new Date(Date.now() - 10_000);
+			await writePaidChallengeRecord(
+				{
+					challengeId,
+					requestId: crypto.randomUUID(),
+					clientAgentId: `agent://${clientAddr}`,
+					resourceId: "refund-fail-resource",
+					tierId: DEFAULT_TIER_ID,
+					amount: "$0.10",
+					amountRaw: 100_000n,
+					destination: agentgateAddr,
+					fromAddress: clientAddr,
+					txHash: `0x${"cd".repeat(32)}` as `0x${string}`,
+					paidAt,
+				},
+				redis,
+			);
+
+			// Poll until cron transitions to REFUND_FAILED
+			// (empty wallet → transferWithAuthorization reverts → REFUND_FAILED)
+			const finalState = await waitForChallengeState(
+				async () => {
+					const s = await redis!.hget(`agentgate:challenge:${challengeId}`, "state");
+					// Accept both REFUND_FAILED and REFUNDED (in case wallet has dust)
+					return s === "REFUND_FAILED" || s === "REFUNDED" ? s : null;
+				},
+				"REFUND_FAILED",
+				REFUND_POLL_TIMEOUT_MS,
+			);
+
+			// Wallet has 0 USDC → must fail
+			expect(finalState).toBe("REFUND_FAILED");
+		},
+		REFUND_POLL_TIMEOUT_MS + 10_000,
+	);
+});

--- a/e2e/scenarios/refund-failure.test.ts
+++ b/e2e/scenarios/refund-failure.test.ts
@@ -9,10 +9,14 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import Redis from "ioredis";
-import { REFUND_FAIL_REDIS_URL, REFUND_POLL_TIMEOUT_MS, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import {
+	DEFAULT_TIER_ID,
+	REFUND_FAIL_REDIS_URL,
+	REFUND_POLL_TIMEOUT_MS,
+} from "../fixtures/constants.ts";
 import { agentgateWalletAddress, clientWalletAddress } from "../fixtures/wallets.ts";
-import { writePaidChallengeRecord } from "../helpers/redis-client.ts";
 import { printLogs, startDockerStack, stopDockerStack } from "../helpers/docker-manager.ts";
+import { writePaidChallengeRecord } from "../helpers/redis-client.ts";
 import { waitForChallengeState } from "../helpers/wait.ts";
 
 const STACK_CONFIG = {

--- a/e2e/scenarios/refund-success.test.ts
+++ b/e2e/scenarios/refund-success.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Refund Success — verifies PAID records are refunded by the cron.
+ *
+ * Setup: write a PAID record directly to Redis (faster than going through the full payment
+ * flow, and doesn't depend on the token issuance failure path).
+ *
+ * The record has fromAddress = CLIENT_WALLET_ADDRESS and amountRaw = $0.01 USDC.
+ * The refund cron picks it up (after REFUND_MIN_AGE_MS = 3s), sends USDC back,
+ * and transitions the record to REFUNDED.
+ *
+ * USDC cost per run: $0.01 (the refunded amount is sent from AGENTGATE_WALLET to client).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	REFUND_POLL_TIMEOUT_MS,
+	DEFAULT_TIER_ID,
+} from "../fixtures/constants.ts";
+import { agentgateWalletAddress, clientWalletAddress } from "../fixtures/wallets.ts";
+import { connectRedis, readChallengeState, writePaidChallengeRecord } from "../helpers/redis-client.ts";
+import { waitForChallengeState } from "../helpers/wait.ts";
+
+// $0.01 USDC — small amount to minimize testnet spend
+const REFUND_AMOUNT_RAW = 10_000n;
+
+describe("Refund Success", () => {
+	test(
+		"PAID record with fromAddress is refunded by the cron within timeout",
+		async () => {
+			const challengeId = `e2e-refund-${crypto.randomUUID()}`;
+			const clientAddr = clientWalletAddress();
+			const agentgateAddr = agentgateWalletAddress();
+			const redis = connectRedis();
+
+			// Record balance before refund
+			// (actual USDC check requires on-chain read — simplified here to state check)
+
+			// Write a PAID record to Redis that is past REFUND_MIN_AGE_MS (3s)
+			// paidAt is in the past to be immediately eligible
+			const paidAt = new Date(Date.now() - 10_000); // 10 seconds ago
+			await writePaidChallengeRecord(
+				{
+					challengeId,
+					requestId: crypto.randomUUID(),
+					clientAgentId: `agent://${clientAddr}`,
+					resourceId: "refund-test-resource",
+					tierId: DEFAULT_TIER_ID,
+					amount: "$0.01",
+					amountRaw: REFUND_AMOUNT_RAW,
+					destination: agentgateAddr,
+					fromAddress: clientAddr,
+					txHash: `0x${"ab".repeat(32)}` as `0x${string}`,
+					paidAt,
+				},
+				redis,
+			);
+
+			// Verify initial state
+			const initialState = await readChallengeState(challengeId, redis);
+			expect(initialState).toBe("PAID");
+
+			// Poll until refund cron transitions to REFUNDED (or REFUND_FAILED = also accepted, check error)
+			const finalState = await waitForChallengeState(
+				() => readChallengeState(challengeId, redis),
+				"REFUNDED",
+				REFUND_POLL_TIMEOUT_MS,
+			);
+
+			expect(finalState).toBe("REFUNDED");
+		},
+		REFUND_POLL_TIMEOUT_MS + 10_000,
+	);
+});

--- a/e2e/scenarios/refund-success.test.ts
+++ b/e2e/scenarios/refund-success.test.ts
@@ -12,12 +12,13 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import {
-	REFUND_POLL_TIMEOUT_MS,
-	DEFAULT_TIER_ID,
-} from "../fixtures/constants.ts";
+import { DEFAULT_TIER_ID, REFUND_POLL_TIMEOUT_MS } from "../fixtures/constants.ts";
 import { agentgateWalletAddress, clientWalletAddress } from "../fixtures/wallets.ts";
-import { connectRedis, readChallengeState, writePaidChallengeRecord } from "../helpers/redis-client.ts";
+import {
+	connectRedis,
+	readChallengeState,
+	writePaidChallengeRecord,
+} from "../helpers/redis-client.ts";
 import { waitForChallengeState } from "../helpers/wait.ts";
 
 // $0.01 USDC — small amount to minimize testnet spend

--- a/e2e/scenarios/token-issuance-failure.test.ts
+++ b/e2e/scenarios/token-issuance-failure.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Token Issuance Failure — critical invariant: record stays PAID when token issuance fails.
+ *
+ * Security invariant: if onIssueToken fails, the challenge record MUST remain in PAID state
+ * so the refund cron can pick it up. It must NOT be rolled back to PENDING or deleted.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { BACKEND_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+import { readChallengeState } from "../helpers/redis-client.ts";
+
+beforeEach(async () => {
+	// Set backend to fail mode
+	const res = await fetch(`${BACKEND_URL}/test/set-mode`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ mode: "fail" }),
+	});
+	expect(res.status).toBe(204);
+});
+
+afterEach(async () => {
+	// Reset backend to success mode
+	await fetch(`${BACKEND_URL}/test/set-mode`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ mode: "success" }),
+	});
+});
+
+describe("Token Issuance Failure", () => {
+	test(
+		"challenge stays in PAID state when backend /issue-token returns 500",
+		async () => {
+			const client = makeClientE2eClient();
+			const requestId = crypto.randomUUID();
+
+			// Step 1: Request access
+			const { challengeId, paymentRequired } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+			});
+
+			// Step 2: Sign EIP-3009
+			const requirements = paymentRequired.accepts[0]!;
+			const auth = await client.signEIP3009({
+				destination: requirements.payTo as `0x${string}`,
+				amountRaw: BigInt(requirements.amount),
+			});
+
+			// Step 3: Submit payment — gas wallet settles, but backend returns 500
+			// AgentGate should return an error response (HTTP 500)
+			const result = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+				auth,
+				paymentRequired,
+			});
+
+			expect(result.status).toBe(500);
+			expect(result.error).toBeDefined();
+
+			// Critical invariant: challenge must be in PAID state (not DELIVERED, not PENDING)
+			const state = await readChallengeState(challengeId);
+			expect(state).toBe("PAID");
+		},
+		120_000,
+	);
+});

--- a/e2e/scenarios/token-issuance-failure.test.ts
+++ b/e2e/scenarios/token-issuance-failure.test.ts
@@ -30,41 +30,37 @@ afterEach(async () => {
 });
 
 describe("Token Issuance Failure", () => {
-	test(
-		"challenge stays in PAID state when backend /issue-token returns 500",
-		async () => {
-			const client = makeClientE2eClient();
-			const requestId = crypto.randomUUID();
+	test("challenge stays in PAID state when backend /issue-token returns 500", async () => {
+		const client = makeClientE2eClient();
+		const requestId = crypto.randomUUID();
 
-			// Step 1: Request access
-			const { challengeId, paymentRequired } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-			});
+		// Step 1: Request access
+		const { challengeId, paymentRequired } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+		});
 
-			// Step 2: Sign EIP-3009
-			const requirements = paymentRequired.accepts[0]!;
-			const auth = await client.signEIP3009({
-				destination: requirements.payTo as `0x${string}`,
-				amountRaw: BigInt(requirements.amount),
-			});
+		// Step 2: Sign EIP-3009
+		const requirements = paymentRequired.accepts[0]!;
+		const auth = await client.signEIP3009({
+			destination: requirements.payTo as `0x${string}`,
+			amountRaw: BigInt(requirements.amount),
+		});
 
-			// Step 3: Submit payment — gas wallet settles, but backend returns 500
-			// AgentGate should return an error response (HTTP 500)
-			const result = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-				auth,
-				paymentRequired,
-			});
+		// Step 3: Submit payment — gas wallet settles, but backend returns 500
+		// AgentGate should return an error response (HTTP 500)
+		const result = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+			auth,
+			paymentRequired,
+		});
 
-			expect(result.status).toBe(500);
-			expect(result.error).toBeDefined();
+		expect(result.status).toBe(500);
+		expect(result.error).toBeDefined();
 
-			// Critical invariant: challenge must be in PAID state (not DELIVERED, not PENDING)
-			const state = await readChallengeState(challengeId);
-			expect(state).toBe("PAID");
-		},
-		120_000,
-	);
+		// Critical invariant: challenge must be in PAID state (not DELIVERED, not PENDING)
+		const state = await readChallengeState(challengeId);
+		expect(state).toBe("PAID");
+	}, 120_000);
 });

--- a/e2e/scenarios/wrong-amount.test.ts
+++ b/e2e/scenarios/wrong-amount.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Wrong Amount — verifies underpayment is rejected.
+ *
+ * Signs EIP-3009 with value=1 (1 micro-USDC) instead of the required $0.10.
+ * ExactEvmScheme.verify() detects the mismatch → PAYMENT_FAILED.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+describe("Wrong Amount", () => {
+	test(
+		"underpayment (1 micro-USDC) is rejected by the settlement layer",
+		async () => {
+			const client = makeClientE2eClient();
+			const requestId = crypto.randomUUID();
+
+			const { paymentRequired } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+			});
+
+			const requirements = paymentRequired.accepts[0]!;
+			const destination = requirements.payTo as `0x${string}`;
+
+			// Sign with 1 micro-USDC instead of the required amount
+			const auth = await client.signEIP3009({
+				destination,
+				amountRaw: 1n, // deliberately wrong
+			});
+
+			const result = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+				auth,
+				paymentRequired,
+			});
+
+			expect(result.status).not.toBe(200);
+			expect(result.error).toBeDefined();
+		},
+		120_000,
+	);
+});

--- a/e2e/scenarios/wrong-amount.test.ts
+++ b/e2e/scenarios/wrong-amount.test.ts
@@ -10,36 +10,32 @@ import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
 import { makeClientE2eClient } from "../fixtures/wallets.ts";
 
 describe("Wrong Amount", () => {
-	test(
-		"underpayment (1 micro-USDC) is rejected by the settlement layer",
-		async () => {
-			const client = makeClientE2eClient();
-			const requestId = crypto.randomUUID();
+	test("underpayment (1 micro-USDC) is rejected by the settlement layer", async () => {
+		const client = makeClientE2eClient();
+		const requestId = crypto.randomUUID();
 
-			const { paymentRequired } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-			});
+		const { paymentRequired } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+		});
 
-			const requirements = paymentRequired.accepts[0]!;
-			const destination = requirements.payTo as `0x${string}`;
+		const requirements = paymentRequired.accepts[0]!;
+		const destination = requirements.payTo as `0x${string}`;
 
-			// Sign with 1 micro-USDC instead of the required amount
-			const auth = await client.signEIP3009({
-				destination,
-				amountRaw: 1n, // deliberately wrong
-			});
+		// Sign with 1 micro-USDC instead of the required amount
+		const auth = await client.signEIP3009({
+			destination,
+			amountRaw: 1n, // deliberately wrong
+		});
 
-			const result = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-				auth,
-				paymentRequired,
-			});
+		const result = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+			auth,
+			paymentRequired,
+		});
 
-			expect(result.status).not.toBe(200);
-			expect(result.error).toBeDefined();
-		},
-		120_000,
-	);
+		expect(result.status).not.toBe(200);
+		expect(result.error).toBeDefined();
+	}, 120_000);
 });

--- a/e2e/scenarios/wrong-recipient.test.ts
+++ b/e2e/scenarios/wrong-recipient.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Wrong Recipient — verifies transfers to the wrong address are rejected.
+ *
+ * Signs EIP-3009 to a random address (not the seller wallet).
+ * ExactEvmScheme.verify() compares `to` vs paymentRequirements.payTo → mismatch → PAYMENT_FAILED.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+import { makeClientE2eClient } from "../fixtures/wallets.ts";
+
+const RANDOM_ADDRESS = "0x000000000000000000000000000000000000dEaD" as `0x${string}`;
+
+describe("Wrong Recipient", () => {
+	test(
+		"payment to wrong address is rejected by the settlement layer",
+		async () => {
+			const client = makeClientE2eClient();
+			const requestId = crypto.randomUUID();
+
+			const { paymentRequired } = await client.requestAccess({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+			});
+
+			const requirements = paymentRequired.accepts[0]!;
+			const correctAmount = BigInt(requirements.amount);
+
+			// Sign to the WRONG address (not the seller's payTo)
+			const auth = await client.signEIP3009({
+				destination: RANDOM_ADDRESS, // deliberately wrong recipient
+				amountRaw: correctAmount,
+			});
+
+			const result = await client.submitPayment({
+				tierId: DEFAULT_TIER_ID,
+				requestId,
+				auth,
+				paymentRequired,
+			});
+
+			expect(result.status).not.toBe(200);
+			expect(result.error).toBeDefined();
+		},
+		120_000,
+	);
+});

--- a/e2e/scenarios/wrong-recipient.test.ts
+++ b/e2e/scenarios/wrong-recipient.test.ts
@@ -12,36 +12,32 @@ import { makeClientE2eClient } from "../fixtures/wallets.ts";
 const RANDOM_ADDRESS = "0x000000000000000000000000000000000000dEaD" as `0x${string}`;
 
 describe("Wrong Recipient", () => {
-	test(
-		"payment to wrong address is rejected by the settlement layer",
-		async () => {
-			const client = makeClientE2eClient();
-			const requestId = crypto.randomUUID();
+	test("payment to wrong address is rejected by the settlement layer", async () => {
+		const client = makeClientE2eClient();
+		const requestId = crypto.randomUUID();
 
-			const { paymentRequired } = await client.requestAccess({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-			});
+		const { paymentRequired } = await client.requestAccess({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+		});
 
-			const requirements = paymentRequired.accepts[0]!;
-			const correctAmount = BigInt(requirements.amount);
+		const requirements = paymentRequired.accepts[0]!;
+		const correctAmount = BigInt(requirements.amount);
 
-			// Sign to the WRONG address (not the seller's payTo)
-			const auth = await client.signEIP3009({
-				destination: RANDOM_ADDRESS, // deliberately wrong recipient
-				amountRaw: correctAmount,
-			});
+		// Sign to the WRONG address (not the seller's payTo)
+		const auth = await client.signEIP3009({
+			destination: RANDOM_ADDRESS, // deliberately wrong recipient
+			amountRaw: correctAmount,
+		});
 
-			const result = await client.submitPayment({
-				tierId: DEFAULT_TIER_ID,
-				requestId,
-				auth,
-				paymentRequired,
-			});
+		const result = await client.submitPayment({
+			tierId: DEFAULT_TIER_ID,
+			requestId,
+			auth,
+			paymentRequired,
+		});
 
-			expect(result.status).not.toBe(200);
-			expect(result.error).toBeDefined();
-		},
-		120_000,
-	);
+		expect(result.status).not.toBe(200);
+		expect(result.error).toBeDefined();
+	}, 120_000);
 });

--- a/e2e/scenarios/x402-discovery.test.ts
+++ b/e2e/scenarios/x402-discovery.test.ts
@@ -1,0 +1,83 @@
+/**
+ * x402 Discovery — verifies the discovery flow via POST /x402/access with no tierId.
+ *
+ * When a client POSTs to /x402/access without a tierId, AgentGate returns HTTP 402
+ * with all available tiers in the accepts array. No PENDING record is created.
+ * This is the entry point for clients that don't yet know which tier to purchase.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AGENTGATE_URL, DEFAULT_TIER_ID } from "../fixtures/constants.ts";
+
+describe("x402 Discovery", () => {
+	test("POST /x402/access with no body returns 402 with all tiers", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(402);
+
+		const body = (await res.json()) as Record<string, unknown>;
+		const accepts = body["accepts"] as Array<Record<string, unknown>>;
+
+		expect(Array.isArray(accepts)).toBe(true);
+		expect(accepts.length).toBeGreaterThan(0);
+
+		// Each tier in accepts must have required x402 fields
+		const tier = accepts[0]!;
+		expect(tier["scheme"]).toBe("exact");
+		expect(tier["network"]).toBe("eip155:84532");
+		expect(typeof tier["asset"]).toBe("string");
+		expect(typeof tier["amount"]).toBe("string");
+		expect(BigInt(tier["amount"] as string)).toBeGreaterThan(0n);
+		expect(typeof tier["payTo"]).toBe("string");
+
+		// Discovery tiers include tierId in extra
+		const extra = tier["extra"] as Record<string, unknown> | undefined;
+		expect(typeof extra?.["tierId"]).toBe("string");
+		expect(extra?.["tierId"]).toBe(DEFAULT_TIER_ID);
+
+		// No challengeId — pure discovery, no PENDING record created
+		expect(body["challengeId"]).toBeUndefined();
+
+		// payment-required header is set
+		const header = res.headers.get("payment-required");
+		expect(header).toBeTruthy();
+		const decoded = JSON.parse(Buffer.from(header!, "base64").toString("utf-8"));
+		expect(decoded.x402Version).toBe(2);
+	});
+
+	test("discovery response includes agentgate extensions with input/output schema", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(402);
+		const body = (await res.json()) as Record<string, unknown>;
+
+		const extensions = body["extensions"] as Record<string, unknown> | undefined;
+		expect(extensions).toBeDefined();
+
+		const agentgate = extensions?.["agentgate"] as Record<string, unknown> | undefined;
+		expect(agentgate).toBeDefined();
+		expect(agentgate?.["inputSchema"]).toBeDefined();
+		expect(agentgate?.["outputSchema"]).toBeDefined();
+	});
+
+	test("www-authenticate header is set on discovery response", async () => {
+		const res = await fetch(`${AGENTGATE_URL}/x402/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(402);
+		const wwwAuth = res.headers.get("www-authenticate");
+		expect(wwwAuth).toBeTruthy();
+		expect(wwwAuth).toContain("Payment");
+	});
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["."]
+}

--- a/examples/backend-integration/server.ts
+++ b/examples/backend-integration/server.ts
@@ -10,8 +10,8 @@
  *   bun run start
  */
 
-import { validateAgentGateToken } from "@riklr/agentgate";
 import type { AccessTokenPayload } from "@riklr/agentgate";
+import { validateAgentGateToken } from "@riklr/agentgate";
 import express from "express";
 
 const PORT = Number(process.env.PORT ?? 3000);
@@ -186,7 +186,7 @@ app.get("/api/data/:id", (req, res) => {
 });
 
 // Health check
-app.get("/health", (req, res) => {
+app.get("/health", (_req, res) => {
 	res.json({ status: "ok", service: "backend" });
 });
 

--- a/examples/client-agent/agent.ts
+++ b/examples/client-agent/agent.ts
@@ -17,8 +17,8 @@
  */
 
 import type { AccessGrant, AgentCard, NetworkName, X402Challenge } from "@riklr/agentgate";
-import { CHAIN_CONFIGS, USDC_ABI, parseDollarToUsdcMicro } from "@riklr/agentgate";
-import { http, createPublicClient, createWalletClient, formatUnits } from "viem";
+import { CHAIN_CONFIGS, parseDollarToUsdcMicro, USDC_ABI } from "@riklr/agentgate";
+import { createPublicClient, createWalletClient, formatUnits, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base, baseSepolia } from "viem/chains";
 

--- a/examples/express-seller/server.ts
+++ b/examples/express-seller/server.ts
@@ -1,10 +1,10 @@
+import type { NetworkName } from "@riklr/agentgate";
 import {
 	AccessTokenIssuer,
 	RedisChallengeStore,
 	RedisSeenTxStore,
 	X402Adapter,
 } from "@riklr/agentgate";
-import type { NetworkName } from "@riklr/agentgate";
 import { agentGateRouter, validateAccessToken } from "@riklr/agentgate/express";
 import express from "express";
 import Redis from "ioredis";

--- a/examples/hono-seller/server.ts
+++ b/examples/hono-seller/server.ts
@@ -1,5 +1,5 @@
-import { AccessTokenIssuer, X402Adapter } from "@riklr/agentgate";
 import type { NetworkName } from "@riklr/agentgate";
+import { AccessTokenIssuer, X402Adapter } from "@riklr/agentgate";
 import { agentGateApp, honoValidateAccessToken } from "@riklr/agentgate/hono";
 import { Hono } from "hono";
 

--- a/examples/refund-cron-example/check-balance.ts
+++ b/examples/refund-cron-example/check-balance.ts
@@ -1,4 +1,4 @@
-import { http, createPublicClient, formatUnits } from "viem";
+import { createPublicClient, formatUnits, http } from "viem";
 import { base, baseSepolia } from "viem/chains";
 
 const NETWORK = process.env["AGENTGATE_NETWORK"] ?? "testnet";

--- a/examples/refund-cron-example/server.ts
+++ b/examples/refund-cron-example/server.ts
@@ -1,11 +1,11 @@
+import type { NetworkName } from "@riklr/agentgate";
 import {
 	AccessTokenIssuer,
+	processRefunds,
 	RedisChallengeStore,
 	RedisSeenTxStore,
 	X402Adapter,
-	processRefunds,
 } from "@riklr/agentgate";
-import type { NetworkName } from "@riklr/agentgate";
 import { agentGateRouter, validateAccessToken } from "@riklr/agentgate/express";
 import { Queue, Worker } from "bullmq";
 import express from "express";
@@ -32,7 +32,7 @@ const adapter = new X402Adapter({
 	rpcUrl: process.env["AGENTGATE_RPC_URL"],
 });
 
-const tokenIssuer = new AccessTokenIssuer(SECRET);
+const _tokenIssuer = new AccessTokenIssuer(SECRET);
 
 // ─── Redis + Store ────────────────────────────────────────────────────────────
 

--- a/examples/simple-x402-client.ts
+++ b/examples/simple-x402-client.ts
@@ -17,8 +17,8 @@
  */
 
 import type { AccessGrant, AgentCard } from "@riklr/agentgate";
-import { CHAIN_CONFIGS, USDC_ABI, parseDollarToUsdcMicro } from "@riklr/agentgate";
-import { http, createPublicClient, createWalletClient, formatUnits } from "viem";
+import { CHAIN_CONFIGS, parseDollarToUsdcMicro, USDC_ABI } from "@riklr/agentgate";
+import { createPublicClient, createWalletClient, formatUnits, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 

--- a/examples/standalone-service/server.ts
+++ b/examples/standalone-service/server.ts
@@ -19,19 +19,19 @@
 import {
 	AccessTokenIssuer,
 	type AuthHeaderProvider,
+	createRemoteResourceVerifier,
+	createRemoteTokenIssuer,
 	type IChallengeStore,
 	type ISeenTxStore,
 	type IssueTokenParams,
 	type NetworkName,
+	processRefunds,
 	RedisChallengeStore,
 	RedisSeenTxStore,
-	type TokenIssuanceResult,
-	X402Adapter,
-	createRemoteResourceVerifier,
-	createRemoteTokenIssuer,
-	processRefunds,
 	sharedSecretAuth,
 	signedJwtAuth,
+	type TokenIssuanceResult,
+	X402Adapter,
 } from "@riklr/agentgate";
 import { agentGateRouter } from "@riklr/agentgate/express";
 import { Queue, Worker } from "bullmq";
@@ -218,7 +218,7 @@ app.use(
 );
 
 // Health check
-app.get("/health", (req, res) => {
+app.get("/health", (_req, res) => {
 	res.json({
 		status: "ok",
 		service: "agentgate",
@@ -228,7 +228,7 @@ app.get("/health", (req, res) => {
 });
 
 // Token info endpoint (for backend to discover token format)
-app.get("/.well-known/token-info", (req, res) => {
+app.get("/.well-known/token-info", (_req, res) => {
 	res.json({
 		tokenType: "JWT",
 		algorithm: tokenMode === "remote" ? "custom" : "HS256", // Could be RS256 if configured

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"type": "module",
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
-	"files": ["src", "dist"],
+	"files": [
+		"src",
+		"dist"
+	],
 	"exports": {
 		".": "./src/index.ts",
 		"./express": "./src/integrations/express.ts",

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -62,19 +62,19 @@ class MockEventBus implements ExecutionEventBus {
 		this.events.push(message);
 	}
 
-	on(eventName: ExecutionEventName, listener: (event: AgentExecutionEvent) => void): this {
+	on(_eventName: ExecutionEventName, _listener: (event: AgentExecutionEvent) => void): this {
 		return this;
 	}
 
-	off(eventName: ExecutionEventName, listener: (event: AgentExecutionEvent) => void): this {
+	off(_eventName: ExecutionEventName, _listener: (event: AgentExecutionEvent) => void): this {
 		return this;
 	}
 
-	once(eventName: ExecutionEventName, listener: (event: AgentExecutionEvent) => void): this {
+	once(_eventName: ExecutionEventName, _listener: (event: AgentExecutionEvent) => void): this {
 		return this;
 	}
 
-	removeAllListeners(eventName?: ExecutionEventName): this {
+	removeAllListeners(_eventName?: ExecutionEventName): this {
 		return this;
 	}
 }
@@ -148,7 +148,12 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 	test("1. AccessRequest → input-required Task with x402 metadata", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
-		const { executor, agentCard } = createAgentGate({ config, adapter, store: new TestChallengeStore(), seenTxStore: new TestSeenTxStore() });
+		const { executor, agentCard } = createAgentGate({
+			config,
+			adapter,
+			store: new TestChallengeStore(),
+			seenTxStore: new TestSeenTxStore(),
+		});
 
 		// Agent card check
 		expect(agentCard.name).toBe("E2E Test Agent");
@@ -197,7 +202,12 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 	test("2. Idempotent access request returns same challenge", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
-		const { executor } = createAgentGate({ config, adapter, store: new TestChallengeStore(), seenTxStore: new TestSeenTxStore() });
+		const { executor } = createAgentGate({
+			config,
+			adapter,
+			store: new TestChallengeStore(),
+			seenTxStore: new TestSeenTxStore(),
+		});
 
 		const requestId = uuidv4();
 		const reqData = {
@@ -219,7 +229,12 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 	test("3. Resource not found returns failed task", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
-		const { executor } = createAgentGate({ config, adapter, store: new TestChallengeStore(), seenTxStore: new TestSeenTxStore() });
+		const { executor } = createAgentGate({
+			config,
+			adapter,
+			store: new TestChallengeStore(),
+			seenTxStore: new TestSeenTxStore(),
+		});
 
 		const events = await runTask(executor, {
 			type: "AccessRequest",
@@ -239,7 +254,12 @@ describe("E2E: Full AgentGate lifecycle (x402 Extension)", () => {
 	test("4. Default resourceId when not provided", async () => {
 		const adapter = new MockPaymentAdapter();
 		const config = makeConfig();
-		const { executor } = createAgentGate({ config, adapter, store: new TestChallengeStore(), seenTxStore: new TestSeenTxStore() });
+		const { executor } = createAgentGate({
+			config,
+			adapter,
+			store: new TestChallengeStore(),
+			seenTxStore: new TestSeenTxStore(),
+		});
 
 		const events = await runTask(executor, {
 			type: "AccessRequest",

--- a/src/__tests__/x402-http-middleware.test.ts
+++ b/src/__tests__/x402-http-middleware.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { NextFunction, Request, Response } from "express";
 import { ChallengeEngine } from "../core/challenge-engine.js";
-import { TestChallengeStore, TestSeenTxStore } from "../test-utils/stores.js";
 import {
 	buildHttpPaymentRequirements,
 	createX402HttpMiddleware,
@@ -9,6 +8,7 @@ import {
 	settleViaFacilitator,
 } from "../integrations/x402-http-middleware.js";
 import { MockPaymentAdapter } from "../test-utils/index.js";
+import { TestChallengeStore, TestSeenTxStore } from "../test-utils/stores.js";
 import { CHAIN_CONFIGS } from "../types/config-shared.js";
 import type { SellerConfig } from "../types/index.js";
 
@@ -77,7 +77,7 @@ function createMockResponse(): {
 			jsonData = data;
 			return this;
 		},
-		send: function (data: any) {
+		send: function (_data: any) {
 			return this;
 		},
 		setHeader: function (name: string, value: string) {

--- a/src/adapter/__tests__/adapter.test.ts
+++ b/src/adapter/__tests__/adapter.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { IssueChallengeParams, VerifyProofParams } from "../../types";
 import { X402Adapter } from "../adapter.js";
-import { CHAIN_CONFIGS } from "../chain-config.js";
 
 describe("X402Adapter", () => {
 	test("protocol is x402", () => {

--- a/src/adapter/__tests__/usdc.test.ts
+++ b/src/adapter/__tests__/usdc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { USDC_DECIMALS } from "../../types/index.js";
-import { USDC_TRANSFER_EVENT_SIGNATURE, parseDollarToUsdcMicro } from "../usdc.js";
+import { parseDollarToUsdcMicro, USDC_TRANSFER_EVENT_SIGNATURE } from "../usdc.js";
 
 describe("USDC constants", () => {
 	test("USDC_DECIMALS is 6", () => {

--- a/src/adapter/__tests__/verify-transfer.test.ts
+++ b/src/adapter/__tests__/verify-transfer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { encodeAbiParameters, pad } from "viem";
 import type { PublicClient } from "viem";
+import { encodeAbiParameters, pad } from "viem";
 import { CHAIN_CONFIGS } from "../chain-config.js";
 import { USDC_TRANSFER_EVENT_SIGNATURE } from "../usdc.js";
 import { type VerifyTransferParams, verifyTransfer } from "../verify-transfer.js";

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -1,4 +1,4 @@
-import { http, type PublicClient, createPublicClient } from "viem";
+import { createPublicClient, http, type PublicClient } from "viem";
 import { base, baseSepolia } from "viem/chains";
 import type {
 	ChallengePayload,

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -1,9 +1,9 @@
-export {
-	USDC_TRANSFER_EVENT_SIGNATURE,
-	USDC_ABI,
-	parseDollarToUsdcMicro,
-} from "./usdc.js";
-export { verifyTransfer } from "./verify-transfer.js";
-export type { VerifyTransferParams } from "./verify-transfer.js";
-export { X402Adapter } from "./adapter.js";
 export type { X402AdapterConfig } from "./adapter.js";
+export { X402Adapter } from "./adapter.js";
+export {
+	parseDollarToUsdcMicro,
+	USDC_ABI,
+	USDC_TRANSFER_EVENT_SIGNATURE,
+} from "./usdc.js";
+export type { VerifyTransferParams } from "./verify-transfer.js";
+export { verifyTransfer } from "./verify-transfer.js";

--- a/src/adapter/send-usdc.ts
+++ b/src/adapter/send-usdc.ts
@@ -76,14 +76,8 @@ export async function sendUsdc(params: SendUsdcParams): Promise<`0x${string}`> {
 			nonce,
 		};
 
-		// USDC owner signs off-chain
-		const usdcOwnerWalletClient = createWalletClient({
-			account: usdcOwnerAccount,
-			chain,
-			transport: http(networkConfig.rpcUrl),
-		});
-		const signature = await usdcOwnerWalletClient.signTypedData({
-			account: usdcOwnerAccount,
+		// USDC owner signs off-chain — no RPC needed, pure local signing
+		const signature = await usdcOwnerAccount.signTypedData({
 			domain,
 			types,
 			primaryType: "TransferWithAuthorization",

--- a/src/adapter/send-usdc.ts
+++ b/src/adapter/send-usdc.ts
@@ -7,34 +7,121 @@ import { USDC_ABI } from "./usdc.js";
 export type SendUsdcParams = {
 	readonly to: `0x${string}`;
 	readonly amountRaw: bigint;
+	/** Private key of the account that owns the USDC. */
 	readonly privateKey: `0x${string}`;
+	/**
+	 * Optional gas wallet private key. When provided, the USDC owner signs an
+	 * EIP-3009 transferWithAuthorization off-chain, and the gas wallet submits
+	 * the transaction on-chain (paying gas). This avoids needing ETH in the
+	 * USDC-holding wallet.
+	 */
+	readonly gasWalletPrivateKey?: `0x${string}`;
 	readonly networkConfig: NetworkConfig;
 };
 
 /**
- * Send USDC on-chain using a seller's private key.
+ * Send USDC on-chain, optionally using a separate gas wallet via EIP-3009.
  * Waits for transaction confirmation before returning.
  * Used internally by processRefunds to return funds to payers.
  */
 export async function sendUsdc(params: SendUsdcParams): Promise<`0x${string}`> {
-	const { to, amountRaw, privateKey, networkConfig } = params;
+	const { to, amountRaw, privateKey, gasWalletPrivateKey, networkConfig } = params;
 
-	const account = privateKeyToAccount(privateKey);
+	const usdcOwnerAccount = privateKeyToAccount(privateKey);
 	const chain = networkConfig.chainId === 8453 ? base : baseSepolia;
-
-	const walletClient = createWalletClient({
-		account,
-		chain,
-		transport: http(networkConfig.rpcUrl),
-	});
 
 	const publicClient = createPublicClient({
 		chain,
 		transport: http(networkConfig.rpcUrl),
 	});
 
+	if (gasWalletPrivateKey) {
+		// EIP-3009: USDC owner signs off-chain, gas wallet submits on-chain
+		const gasAccount = privateKeyToAccount(gasWalletPrivateKey);
+		const gasWalletClient = createWalletClient({
+			account: gasAccount,
+			chain,
+			transport: http(networkConfig.rpcUrl),
+		});
+
+		// Build EIP-3009 typed data
+		const validAfter = 0n;
+		const validBefore = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour
+		const nonce = `0x${crypto.getRandomValues(new Uint8Array(32)).reduce((hex, b) => hex + b.toString(16).padStart(2, "0"), "")}` as `0x${string}`;
+
+		const domain = {
+			name: networkConfig.usdcDomain.name,
+			version: networkConfig.usdcDomain.version,
+			chainId: networkConfig.chainId,
+			verifyingContract: networkConfig.usdcAddress,
+		} as const;
+
+		const types = {
+			TransferWithAuthorization: [
+				{ name: "from", type: "address" },
+				{ name: "to", type: "address" },
+				{ name: "value", type: "uint256" },
+				{ name: "validAfter", type: "uint256" },
+				{ name: "validBefore", type: "uint256" },
+				{ name: "nonce", type: "bytes32" },
+			],
+		} as const;
+
+		const message = {
+			from: usdcOwnerAccount.address,
+			to,
+			value: amountRaw,
+			validAfter,
+			validBefore,
+			nonce,
+		};
+
+		// USDC owner signs off-chain
+		const usdcOwnerWalletClient = createWalletClient({
+			account: usdcOwnerAccount,
+			chain,
+			transport: http(networkConfig.rpcUrl),
+		});
+		const signature = await usdcOwnerWalletClient.signTypedData({
+			account: usdcOwnerAccount,
+			domain,
+			types,
+			primaryType: "TransferWithAuthorization",
+			message,
+		});
+
+		// Parse the signature into v, r, s
+		const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+		const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+		const v = Number(`0x${signature.slice(130, 132)}`);
+
+		// Gas wallet submits on-chain
+		const txHash = await gasWalletClient.writeContract({
+			account: gasAccount,
+			address: networkConfig.usdcAddress,
+			abi: USDC_ABI,
+			functionName: "transferWithAuthorization",
+			args: [usdcOwnerAccount.address, to, amountRaw, validAfter, validBefore, nonce, v, r, s],
+		});
+
+		const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+		if (receipt.status !== "success") {
+			throw new Error(`Refund transaction reverted: ${txHash}`);
+		}
+
+		return txHash;
+	}
+
+	// Fallback: direct transfer (USDC owner pays gas)
+	const walletClient = createWalletClient({
+		account: usdcOwnerAccount,
+		chain,
+		transport: http(networkConfig.rpcUrl),
+	});
+
 	const txHash = await walletClient.writeContract({
-		account,
+		account: usdcOwnerAccount,
 		address: networkConfig.usdcAddress,
 		abi: USDC_ABI,
 		functionName: "transfer",

--- a/src/adapter/send-usdc.ts
+++ b/src/adapter/send-usdc.ts
@@ -1,4 +1,4 @@
-import { http, createPublicClient, createWalletClient } from "viem";
+import { createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base, baseSepolia } from "viem/chains";
 import type { NetworkConfig } from "../types/index.js";
@@ -47,7 +47,8 @@ export async function sendUsdc(params: SendUsdcParams): Promise<`0x${string}`> {
 		// Build EIP-3009 typed data
 		const validAfter = 0n;
 		const validBefore = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour
-		const nonce = `0x${crypto.getRandomValues(new Uint8Array(32)).reduce((hex, b) => hex + b.toString(16).padStart(2, "0"), "")}` as `0x${string}`;
+		const nonce =
+			`0x${crypto.getRandomValues(new Uint8Array(32)).reduce((hex, b) => hex + b.toString(16).padStart(2, "0"), "")}` as `0x${string}`;
 
 		const domain = {
 			name: networkConfig.usdcDomain.name,

--- a/src/adapter/usdc.ts
+++ b/src/adapter/usdc.ts
@@ -31,6 +31,23 @@ export const USDC_ABI = [
 		outputs: [{ name: "", type: "bool" }],
 		stateMutability: "nonpayable",
 	},
+	{
+		type: "function",
+		name: "transferWithAuthorization",
+		inputs: [
+			{ name: "from", type: "address" },
+			{ name: "to", type: "address" },
+			{ name: "value", type: "uint256" },
+			{ name: "validAfter", type: "uint256" },
+			{ name: "validBefore", type: "uint256" },
+			{ name: "nonce", type: "bytes32" },
+			{ name: "v", type: "uint8" },
+			{ name: "r", type: "bytes32" },
+			{ name: "s", type: "bytes32" },
+		],
+		outputs: [],
+		stateMutability: "nonpayable",
+	},
 ] as const;
 
 /**

--- a/src/adapter/verify-transfer.ts
+++ b/src/adapter/verify-transfer.ts
@@ -1,4 +1,4 @@
-import { type PublicClient, decodeEventLog } from "viem";
+import { decodeEventLog, type PublicClient } from "viem";
 import type { NetworkConfig, VerificationResult } from "../types/index.js";
 import { USDC_ABI, USDC_TRANSFER_EVENT_SIGNATURE } from "./usdc.js";
 

--- a/src/core/__tests__/agent-card.test.ts
+++ b/src/core/__tests__/agent-card.test.ts
@@ -43,7 +43,7 @@ describe("buildAgentCard", () => {
 
 	test("returns card with correct url and version", () => {
 		const card = buildAgentCard(makeConfig({ version: "2.0.0" }));
-		expect(card.url).toBe("https://agent.example.com/a2a/jsonrpc");
+		expect(card.url).toBe("https://agent.example.com/x402/access");
 		expect(card.version).toBe("2.0.0");
 	});
 

--- a/src/core/__tests__/challenge-engine.test.ts
+++ b/src/core/__tests__/challenge-engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { MockPaymentAdapter } from "../../test-utils";
+import { TestChallengeStore, TestSeenTxStore } from "../../test-utils/stores.js";
 import {
 	type AccessRequest,
 	AgentGateError,
@@ -7,7 +8,6 @@ import {
 	type SellerConfig,
 } from "../../types";
 import { ChallengeEngine, type ChallengeEngineConfig } from "../challenge-engine.js";
-import { TestChallengeStore, TestSeenTxStore } from "../../test-utils/stores.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/__tests__/concurrency.test.ts
+++ b/src/core/__tests__/concurrency.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { ChallengeRecord } from "../../types";
 import { TestChallengeStore, TestSeenTxStore } from "../../test-utils/stores.js";
+import type { ChallengeRecord } from "../../types";
 
 function makeChallengeRecord(overrides?: Partial<ChallengeRecord>): ChallengeRecord {
 	return {
@@ -120,7 +120,6 @@ describe("Concurrency — idempotent create", () => {
 
 		await store.create(record);
 		await expect(store.create(record)).rejects.toThrow("already exists");
-
 	});
 
 	test("concurrent creates with same challengeId — one succeeds, one rejects", async () => {

--- a/src/core/__tests__/refund.test.ts
+++ b/src/core/__tests__/refund.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import type { ChallengeRecord } from "../../types/index.js";
 import { TestChallengeStore } from "../../test-utils/stores.js";
+import type { ChallengeRecord } from "../../types/index.js";
 
 // ─── Module mock — intercepts the sendUsdc import inside refund.ts ──────────
 

--- a/src/core/__tests__/storage-redis.test.ts
+++ b/src/core/__tests__/storage-redis.test.ts
@@ -69,11 +69,16 @@ function createMockRedis() {
 			return "OK";
 		},
 
-		eval(_script: string, _numKeys: number, ...args: string[]): number {
-			// Simulate the Lua transition script
+		eval(_script: string, numKeys: number, ...args: string[]): number {
+			// Simulate the Lua transition script.
+			// KEYS[1]=challenge hash, KEYS[2]=paid sorted set
+			// ARGV: [fromState, toState, challengeId, score, ...field/value pairs]
 			const key = args[0] as string;
-			const fromState = args[1] as string;
-			const toState = args[2] as string;
+			const paidSetKey = args[1] as string;
+			const fromState = args[numKeys] as string;
+			const toState = args[numKeys + 1] as string;
+			const challengeId = args[numKeys + 2] as string;
+			const score = args[numKeys + 3] as string;
 
 			const hash = store.get(key);
 			if (!(hash instanceof Map)) return 0;
@@ -82,10 +87,18 @@ function createMockRedis() {
 			if (current !== fromState) return 0;
 
 			hash.set("state", toState);
-			// Apply field/value pairs
-			for (let i = 3; i < args.length; i += 2) {
+			// Apply field/value pairs (start after the 4 fixed ARGV slots)
+			for (let i = numKeys + 4; i < args.length; i += 2) {
 				hash.set(args[i] as string, args[i + 1] as string);
 			}
+
+			// Simulate sorted set maintenance (mirrors the Lua ZADD/ZREM logic)
+			if (toState === "PAID" && score !== "") {
+				mock.zadd(paidSetKey, Number(score), challengeId);
+			} else if (fromState === "PAID") {
+				mock.zrem(paidSetKey, challengeId);
+			}
+
 			return 1;
 		},
 

--- a/src/core/access-token.ts
+++ b/src/core/access-token.ts
@@ -1,4 +1,4 @@
-import { SignJWT, importPKCS8, jwtVerify } from "jose";
+import { importPKCS8, jwtVerify, SignJWT } from "jose";
 
 export type TokenClaims = {
 	readonly sub: string; // requestId

--- a/src/core/agent-card.ts
+++ b/src/core/agent-card.ts
@@ -1,14 +1,12 @@
-import { CHAIN_CONFIGS, CHAIN_ID_TO_NETWORK, X402_EXTENSION_URI } from "../types/index.js";
 import type {
 	AgentCard,
 	AgentExtension,
 	AgentSkill,
-	NetworkConfig,
-	NetworkName,
 	ProductTier,
 	SellerConfig,
 	SkillPricing,
 } from "../types/index.js";
+import { CHAIN_CONFIGS, CHAIN_ID_TO_NETWORK, X402_EXTENSION_URI } from "../types/index.js";
 
 export function buildAgentCard(config: SellerConfig): AgentCard {
 	const networkConfig = CHAIN_CONFIGS[config.network];
@@ -18,7 +16,7 @@ export function buildAgentCard(config: SellerConfig): AgentCard {
 	// Build endpoint URL first (needed for skills)
 	const basePath = config.basePath ?? "/a2a";
 	const baseUrl = config.agentUrl.replace(/\/$/, "");
-	const endpointUrl = `${baseUrl}${basePath}`;
+	const _endpointUrl = `${baseUrl}${basePath}`;
 
 	// Build skills - one per product tier (minimal, reference-style)
 	const skills: AgentSkill[] = config.products.map((tier: ProductTier) => {

--- a/src/core/challenge-engine.ts
+++ b/src/core/challenge-engine.ts
@@ -1,14 +1,15 @@
+import { parseDollarToUsdcMicro } from "../adapter/index.js";
 import {
 	type AccessGrant,
 	type AccessRequest,
 	AgentGateError,
+	CHAIN_CONFIGS,
 	CHAIN_ID_TO_NETWORK,
 	type ChallengeRecord,
 	type IChallengeStore,
 	type IPaymentAdapter,
 	type ISeenTxStore,
 	type NetworkConfig,
-	type NetworkName,
 	type PaymentProof,
 	type ProductTier,
 	type SellerConfig,
@@ -16,9 +17,6 @@ import {
 	type X402PaymentRequiredResponse,
 	type X402SettleResponse,
 } from "../types/index.js";
-
-import { parseDollarToUsdcMicro } from "../adapter/index.js";
-import { CHAIN_CONFIGS } from "../types/index.js";
 import { validateSellerConfig } from "./config-validation.js";
 import { validateNonEmpty, validateTxHash, validateUUID } from "./validation.js";
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,30 +1,25 @@
 // Validation
-export {
-	validateUUID,
-	validateTxHash,
-	validateAddress,
-	validateNonEmpty,
-	validateDollarAmount,
-} from "./validation.js";
 
-// Storage — Redis
-export { RedisChallengeStore, RedisSeenTxStore } from "./storage/redis.js";
-export type { RedisStoreConfig } from "./storage/redis.js";
-
+export type { TokenClaims, TokenResult } from "./access-token.js";
 // Access Token
 export { AccessTokenIssuer } from "./access-token.js";
-export type { TokenClaims, TokenResult } from "./access-token.js";
-
 // Agent Card
 export { buildAgentCard } from "./agent-card.js";
-
-// Config Validation
-export { validateSellerConfig } from "./config-validation.js";
-
+export type { ChallengeEngineConfig } from "./challenge-engine.js";
 // Challenge Engine
 export { ChallengeEngine } from "./challenge-engine.js";
-export type { ChallengeEngineConfig } from "./challenge-engine.js";
-
+// Config Validation
+export { validateSellerConfig } from "./config-validation.js";
+export type { RefundConfig, RefundResult } from "./refund.js";
 // Refund Utility
 export { processRefunds } from "./refund.js";
-export type { RefundConfig, RefundResult } from "./refund.js";
+export type { RedisStoreConfig } from "./storage/redis.js";
+// Storage — Redis
+export { RedisChallengeStore, RedisSeenTxStore } from "./storage/redis.js";
+export {
+	validateAddress,
+	validateDollarAmount,
+	validateNonEmpty,
+	validateTxHash,
+	validateUUID,
+} from "./validation.js";

--- a/src/core/refund.ts
+++ b/src/core/refund.ts
@@ -4,8 +4,14 @@ import type { IChallengeStore, NetworkName } from "../types/index.js";
 
 export type RefundConfig = {
 	readonly store: IChallengeStore;
-	/** Wallet private key — used to send USDC back to payers. */
+	/** Wallet private key — owns the USDC to be refunded. */
 	readonly walletPrivateKey: `0x${string}`;
+	/**
+	 * Optional gas wallet private key. When provided, uses EIP-3009
+	 * transferWithAuthorization so the gas wallet pays gas instead of the
+	 * USDC-holding wallet (which may have no ETH).
+	 */
+	readonly gasWalletPrivateKey?: `0x${string}`;
 	readonly network: NetworkName;
 	/** Grace period before a PAID record is eligible for refund. Default: 300_000 (5 mins). */
 	readonly minAgeMs?: number;
@@ -30,7 +36,7 @@ export type RefundResult = {
  * broadcasting — concurrent cron runs will not double-refund.
  */
 export async function processRefunds(config: RefundConfig): Promise<RefundResult[]> {
-	const { store, walletPrivateKey, network, minAgeMs = 300_000 } = config;
+	const { store, walletPrivateKey, gasWalletPrivateKey, network, minAgeMs = 300_000 } = config;
 	const networkConfig = CHAIN_CONFIGS[network];
 	const results: RefundResult[] = [];
 
@@ -57,6 +63,7 @@ export async function processRefunds(config: RefundConfig): Promise<RefundResult
 				to: fromAddress,
 				amountRaw: record.amountRaw,
 				privateKey: walletPrivateKey,
+				...(gasWalletPrivateKey ? { gasWalletPrivateKey } : {}),
 				networkConfig,
 			});
 

--- a/src/core/refund.ts
+++ b/src/core/refund.ts
@@ -1,6 +1,6 @@
 import { sendUsdc } from "../adapter/send-usdc.js";
-import { CHAIN_CONFIGS } from "../types/index.js";
 import type { IChallengeStore, NetworkName } from "../types/index.js";
+import { CHAIN_CONFIGS } from "../types/index.js";
 
 export type RefundConfig = {
 	readonly store: IChallengeStore;

--- a/src/core/storage/redis.ts
+++ b/src/core/storage/redis.ts
@@ -100,15 +100,32 @@ function deserializeChallengeRecord(flat: FlatHash): ChallengeRecord | null {
 }
 
 // ─── Lua script for atomic state transition ──────────────────────────
+//
+// KEYS[1] = challenge hash key
+// KEYS[2] = paid sorted set key
+// ARGV[1] = fromState
+// ARGV[2] = toState
+// ARGV[3] = challengeId (used for zadd/zrem)
+// ARGV[4] = paidAt epoch ms as string, or "" if not a PAID transition
+// ARGV[5..] = alternating field/value pairs to write alongside state
 
 const TRANSITION_LUA = `
 local current = redis.call('HGET', KEYS[1], 'state')
 if current ~= ARGV[1] then
   return 0
 end
-redis.call('HSET', KEYS[1], 'state', ARGV[2])
-for i = 3, #ARGV, 2 do
+local fromState = ARGV[1]
+local toState = ARGV[2]
+local challengeId = ARGV[3]
+local score = ARGV[4]
+redis.call('HSET', KEYS[1], 'state', toState)
+for i = 5, #ARGV, 2 do
   redis.call('HSET', KEYS[1], ARGV[i], ARGV[i+1])
+end
+if toState == 'PAID' and score ~= '' then
+  redis.call('ZADD', KEYS[2], score, challengeId)
+elseif fromState == 'PAID' then
+  redis.call('ZREM', KEYS[2], challengeId)
 end
 return 1
 `;
@@ -193,9 +210,14 @@ export class RedisChallengeStore implements IChallengeStore {
 		updates?: ChallengeTransitionUpdates,
 	): Promise<boolean> {
 		const key = this.challengeKey(challengeId);
+		const paidSetKey = this.paidSetKey();
 
-		// Build Lua ARGV: [fromState, toState, ...field/value pairs]
-		const argv: string[] = [fromState, toState];
+		// ARGV layout: [fromState, toState, challengeId, paidAtScore, ...field/value pairs]
+		// paidAtScore is the paidAt epoch ms (for ZADD on PAID transitions), or "" otherwise.
+		const score = toState === "PAID" && updates?.paidAt
+			? updates.paidAt.getTime().toString()
+			: "";
+		const argv: string[] = [fromState, toState, challengeId, score];
 
 		if (updates) {
 			if (updates.txHash) {
@@ -224,17 +246,13 @@ export class RedisChallengeStore implements IChallengeStore {
 			}
 		}
 
-		const result = await this.redis.eval(TRANSITION_LUA, 1, key, ...argv);
+		// KEYS[1] = challenge hash, KEYS[2] = paid sorted set
+		// Sorted set maintenance (ZADD/ZREM) is inside the Lua script — fully atomic.
+		const result = await this.redis.eval(TRANSITION_LUA, 2, key, paidSetKey, ...argv);
 		if (result !== 1) return false;
 
-		// Maintain agentgate:paid sorted set for efficient refund cron queries
-		if (toState === "PAID" && updates?.paidAt) {
-			await this.redis.zadd(this.paidSetKey(), updates.paidAt.getTime(), challengeId);
-		} else if (fromState === "PAID") {
-			await this.redis.zrem(this.paidSetKey(), challengeId);
-		}
-
-		// DELIVERED records no longer need the full 7-day window — shorten TTL to 12 hours
+		// DELIVERED records no longer need the full 7-day window — shorten TTL to 12 hours.
+		// This EXPIRE is intentionally outside Lua (TTL adjustment, not a correctness invariant).
 		if (toState === "DELIVERED") {
 			await this.redis.expire(key, this.deliveredTTL);
 		}

--- a/src/core/storage/redis.ts
+++ b/src/core/storage/redis.ts
@@ -214,9 +214,7 @@ export class RedisChallengeStore implements IChallengeStore {
 
 		// ARGV layout: [fromState, toState, challengeId, paidAtScore, ...field/value pairs]
 		// paidAtScore is the paidAt epoch ms (for ZADD on PAID transitions), or "" otherwise.
-		const score = toState === "PAID" && updates?.paidAt
-			? updates.paidAt.getTime().toString()
-			: "";
+		const score = toState === "PAID" && updates?.paidAt ? updates.paidAt.getTime().toString() : "";
 		const argv: string[] = [fromState, toState, challengeId, score];
 
 		if (updates) {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,5 +1,5 @@
 import { DefaultRequestHandler, InMemoryTaskStore } from "@a2a-js/sdk/server";
-import { ChallengeEngine, buildAgentCard } from "./core/index.js";
+import { buildAgentCard, ChallengeEngine } from "./core/index.js";
 import { AgentGateExecutor } from "./executor.js";
 import type {
 	AgentCard,

--- a/src/helpers/__tests__/remote.test.ts
+++ b/src/helpers/__tests__/remote.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
-import { AgentGateError } from "../../types/index.js";
 import type { IssueTokenParams } from "../../types/index.js";
+import { AgentGateError } from "../../types/index.js";
 import { createRemoteResourceVerifier, createRemoteTokenIssuer } from "../remote.js";
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/remote.ts
+++ b/src/helpers/remote.ts
@@ -1,5 +1,5 @@
-import { AgentGateError } from "../types/index.js";
 import type { IssueTokenParams, ResourceVerifier, TokenIssuanceResult } from "../types/index.js";
+import { AgentGateError } from "../types/index.js";
 import { type AuthHeaderProvider, sharedSecretAuth } from "./auth.js";
 
 export type RemoteVerifierConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,31 @@
 // Export Types
-export * from "./types/index.js";
+
+// Export A2A types if needed, or rely on @a2a-js/sdk
+export type { AgentExecutor, ExecutionEventBus, RequestContext } from "@a2a-js/sdk/server";
 
 // Export Adapter Logic
 export * from "./adapter/index.js";
 
 // Export Core Logic
 export * from "./core/index.js";
-
+// Executor
+export { AgentGateExecutor } from "./executor.js";
+export type { AgentGateConfig } from "./factory.js";
+// Factory
+export { createAgentGate } from "./factory.js";
+export type { AuthHeaderProvider } from "./helpers/auth.js";
+// Auth Strategies
+export { oauthClientCredentialsAuth, sharedSecretAuth, signedJwtAuth } from "./helpers/auth.js";
+export type { RemoteTokenIssuerConfig, RemoteVerifierConfig } from "./helpers/remote.js";
+// Remote Helpers (for separate service deployments)
+export { createRemoteResourceVerifier, createRemoteTokenIssuer } from "./helpers/remote.js";
+export type { AccessTokenPayload, ValidateAccessTokenConfig } from "./middleware.js";
 // Middleware
 export { validateToken } from "./middleware.js";
-export type { AccessTokenPayload, ValidateAccessTokenConfig } from "./middleware.js";
-
-// Validator (lightweight for backend services)
-export { validateAgentGateToken } from "./validator/index.js";
+export * from "./types/index.js";
 export type {
 	AccessTokenPayload as ValidatorAccessTokenPayload,
 	ValidatorConfig,
 } from "./validator/index.js";
-
-// Remote Helpers (for separate service deployments)
-export { createRemoteResourceVerifier, createRemoteTokenIssuer } from "./helpers/remote.js";
-export type { RemoteVerifierConfig, RemoteTokenIssuerConfig } from "./helpers/remote.js";
-
-// Auth Strategies
-export { sharedSecretAuth, signedJwtAuth, oauthClientCredentialsAuth } from "./helpers/auth.js";
-export type { AuthHeaderProvider } from "./helpers/auth.js";
-
-// Executor
-export { AgentGateExecutor } from "./executor.js";
-
-// Factory
-export { createAgentGate } from "./factory.js";
-export type { AgentGateConfig } from "./factory.js";
-
-// Export A2A types if needed, or rely on @a2a-js/sdk
-export type { AgentExecutor, RequestContext, ExecutionEventBus } from "@a2a-js/sdk/server";
+// Validator (lightweight for backend services)
+export { validateAgentGateToken } from "./validator/index.js";

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -1,16 +1,16 @@
 import { AGENT_CARD_PATH } from "@a2a-js/sdk";
 import {
-	UserBuilder,
 	agentCardHandler,
 	jsonRpcHandler,
 	restHandler,
+	UserBuilder,
 } from "@a2a-js/sdk/server/express";
 import { type NextFunction, type Request, type Response, Router } from "express";
 import { type AgentGateConfig, createAgentGate } from "../factory.js";
 import type { ValidateAccessTokenConfig } from "../middleware.js";
 import { validateToken } from "../middleware.js";
+import type { X402PaymentRequiredResponse } from "../types/index.js";
 import { AgentGateError, CHAIN_CONFIGS } from "../types/index.js";
-import type { AccessRequest, X402PaymentRequiredResponse } from "../types/index.js";
 import {
 	buildDiscoveryResponse,
 	buildHttpPaymentRequirements,
@@ -74,18 +74,21 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 			// ===== CASE 1: No tierId → Discovery (402 with all tiers, no PENDING record) =====
 			if (!tierId) {
 				console.log("[x402-access] → CASE 1: No tierId provided, returning discovery 402");
-				
+
 				const discoveryResponse = buildDiscoveryResponse(opts.config, networkConfig);
-				console.log("[x402-access] Discovery response:", JSON.stringify(discoveryResponse, null, 2));
+				console.log(
+					"[x402-access] Discovery response:",
+					JSON.stringify(discoveryResponse, null, 2),
+				);
 
 				// Encode as base64 for PAYMENT-REQUIRED header
 				const encoded = Buffer.from(JSON.stringify(discoveryResponse)).toString("base64");
 				res.setHeader("payment-required", encoded);
-				
+
 				// Add www-authenticate header for HTTP spec compliance
 				const authHeader = `Payment realm="${opts.config.agentUrl}", accept="exact"`;
 				res.setHeader("www-authenticate", authHeader);
-				
+
 				console.log(`[x402-access] payment-required header set (${encoded.length} bytes)`);
 				console.log(`[x402-access] www-authenticate header set`);
 				console.log("[x402-access] → Returning HTTP 402 Payment Required (Discovery)");
@@ -102,11 +105,15 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 				console.log(`[x402-access] Auto-generated requestId: ${requestId}`);
 			}
 
-			console.log(`[x402-access] Parsed request - tierId: ${tierId}, requestId: ${requestId}, resourceId: ${resourceId}`);
+			console.log(
+				`[x402-access] Parsed request - tierId: ${tierId}, requestId: ${requestId}, resourceId: ${resourceId}`,
+			);
 
 			// ===== CASE 2: tierId present, no PAYMENT-SIGNATURE → Challenge (402 + PENDING record) =====
 			if (!paymentSignature) {
-				console.log("[x402-access] → CASE 2: tierId provided, no PAYMENT-SIGNATURE, issuing 402 challenge");
+				console.log(
+					"[x402-access] → CASE 2: tierId provided, no PAYMENT-SIGNATURE, issuing 402 challenge",
+				);
 				console.log(`[x402-access] Creating PENDING record for requestId: ${requestId}`);
 
 				// Create PENDING record via engine (handles tier/resource validation and idempotency)
@@ -145,7 +152,10 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 								accessToken: { type: "string", description: "JWT token for API access" },
 								tokenType: { type: "string", description: "Token type (usually 'Bearer')" },
 								expiresAt: { type: "string", description: "ISO 8601 expiration timestamp" },
-								resourceEndpoint: { type: "string", description: "URL to access the protected resource" },
+								resourceEndpoint: {
+									type: "string",
+									description: "URL to access the protected resource",
+								},
 								txHash: { type: "string", description: "On-chain transaction hash" },
 								explorerUrl: { type: "string", description: "Blockchain explorer URL" },
 							},
@@ -158,11 +168,11 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 				// Encode as base64 for payment-required header
 				const encoded = Buffer.from(JSON.stringify(requirements)).toString("base64");
 				res.setHeader("payment-required", encoded);
-				
+
 				// Add www-authenticate header
 				const authHeader = `Payment realm="${opts.config.agentUrl}", accept="exact", challenge="${challengeId}"`;
 				res.setHeader("www-authenticate", authHeader);
-				
+
 				console.log(`[x402-access] payment-required header set (${encoded.length} bytes)`);
 				console.log(`[x402-access] www-authenticate header set`);
 				console.log("[x402-access] → Returning HTTP 402 Payment Required (Challenge)");
@@ -176,12 +186,17 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 
 			// ===== CASE 3: tierId + PAYMENT-SIGNATURE → Settle and return access grant =====
 			console.log("[x402-access] → CASE 3: Processing payment");
-			console.log(`[x402-access] PAYMENT-SIGNATURE header received (${paymentSignature.length} bytes)`);
+			console.log(
+				`[x402-access] PAYMENT-SIGNATURE header received (${paymentSignature.length} bytes)`,
+			);
 
 			// Decode header then settle via shared settlement layer
 			console.log("[x402-access] Decoding payment signature...");
 			const paymentPayload = decodePaymentSignature(paymentSignature);
-			console.log("[x402-access] Payment payload decoded:", JSON.stringify(paymentPayload, null, 2));
+			console.log(
+				"[x402-access] Payment payload decoded:",
+				JSON.stringify(paymentPayload, null, 2),
+			);
 
 			console.log("[x402-access] Settling payment on-chain...");
 			const { txHash, settleResponse, payer } = await settlePayment(
@@ -219,7 +234,7 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 			console.error(`[x402-access] ✗ Error occurred after ${elapsed}ms`);
 			console.error("[x402-access] Error type:", err?.constructor?.name || typeof err);
 			console.error("[x402-access] Error details:", err);
-			
+
 			if (err instanceof Error) {
 				console.error("[x402-access] Error message:", err.message);
 				console.error("[x402-access] Error stack:", err.stack);
@@ -229,7 +244,7 @@ export function agentGateRouter(opts: AgentGateConfig): Router {
 				console.error(`[x402-access] AgentGate error: ${err.code} (HTTP ${err.httpStatus})`);
 				return res.status(err.httpStatus).json(err.toJSON());
 			}
-			
+
 			console.error("[x402-access] Returning 500 Internal Server Error");
 			return res.status(500).json({
 				error: "INTERNAL_ERROR",

--- a/src/integrations/settlement.ts
+++ b/src/integrations/settlement.ts
@@ -75,7 +75,18 @@ export function buildHttpPaymentRequirements(
 	const amountRaw = parseDollarToUsdcMicro(tier.amount);
 	const network = `eip155:${networkConfig.chainId}`;
 
-	const response: X402PaymentRequiredResponse = {
+	const extensions =
+		options?.inputSchema || options?.outputSchema || options?.description
+			? {
+					agentgate: {
+						...(options.inputSchema && { inputSchema: options.inputSchema }),
+						...(options.outputSchema && { outputSchema: options.outputSchema }),
+						...(options.description && { description: options.description }),
+					},
+				}
+			: undefined;
+
+	return {
 		x402Version: 2,
 		resource: {
 			url: resourceUrl,
@@ -98,20 +109,8 @@ export function buildHttpPaymentRequirements(
 				},
 			},
 		],
+		...(extensions ? { extensions } : {}),
 	};
-
-	// Add schema if provided
-	if (options?.inputSchema || options?.outputSchema || options?.description) {
-		response.extensions = {
-			agentgate: {
-				...(options.inputSchema && { inputSchema: options.inputSchema }),
-				...(options.outputSchema && { outputSchema: options.outputSchema }),
-				...(options.description && { description: options.description }),
-			},
-		};
-	}
-
-	return response;
 }
 
 /**
@@ -374,12 +373,62 @@ export async function settleViaGasWallet(
 }
 
 // ---------------------------------------------------------------------------
+// Distributed lock helpers (Redis SET NX / Lua release)
+// ---------------------------------------------------------------------------
+
+const LOCK_TTL_MS = 60_000; // 60s — longer than any reasonable settlement
+const LOCK_POLL_MS = 200; // retry interval while waiting for lock
+// Lua script: delete the key only if its value matches our token (atomic)
+const RELEASE_LUA = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end
+`;
+
+async function acquireRedisLock(
+	redis: import("../types/config.js").IRedisLockClient,
+	key: string,
+	token: string,
+): Promise<void> {
+	while (true) {
+		const ok = await redis.set(key, token, "NX", "PX", LOCK_TTL_MS);
+		if (ok === "OK") return;
+		await new Promise((r) => setTimeout(r, LOCK_POLL_MS));
+	}
+}
+
+async function releaseRedisLock(
+	redis: import("../types/config.js").IRedisLockClient,
+	key: string,
+	token: string,
+): Promise<void> {
+	await redis.eval(RELEASE_LUA, 1, key, token);
+}
+
+// ---------------------------------------------------------------------------
+// In-process fallback queue (single-instance only)
+// ---------------------------------------------------------------------------
+
+// Used when no Redis client is configured — serializes settlements within
+// the current process. Does NOT protect against nonce conflicts across
+// multiple instances; set config.redis for multi-instance deployments.
+let gasWalletSettleQueue: Promise<unknown> = Promise.resolve();
+
+// ---------------------------------------------------------------------------
 // Unified settlement entry point
 // ---------------------------------------------------------------------------
 
 /**
  * Settle a payment using the appropriate strategy (gas wallet or facilitator),
  * determined by the seller config. Accepts an already-decoded X402PaymentPayload.
+ *
+ * When gasWalletPrivateKey is set:
+ *   - With config.redis: uses a distributed Redis lock so concurrent settlements
+ *     across multiple instances are serialized (prevents nonce conflicts).
+ *   - Without config.redis: falls back to an in-process serial queue (single
+ *     instance only).
  *
  * Used by both:
  * - HTTP middleware (after decoding the PAYMENT-SIGNATURE header)
@@ -391,8 +440,28 @@ export async function settlePayment(
 	networkConfig: NetworkConfig,
 ): Promise<SettlementResult> {
 	if (config.gasWalletPrivateKey) {
-		return settleViaGasWallet(paymentPayload, config.gasWalletPrivateKey, networkConfig);
+		const privateKey = config.gasWalletPrivateKey;
+
+		if (config.redis) {
+			// Distributed lock — safe across multiple instances
+			const lockKey = `agentgate:settle-lock:${privateKey.slice(0, 10)}`;
+			const lockToken = crypto.randomUUID();
+			await acquireRedisLock(config.redis, lockKey, lockToken);
+			try {
+				return await settleViaGasWallet(paymentPayload, privateKey, networkConfig);
+			} finally {
+				await releaseRedisLock(config.redis, lockKey, lockToken);
+			}
+		}
+
+		// In-process fallback — single instance only
+		const result = gasWalletSettleQueue.then(() =>
+			settleViaGasWallet(paymentPayload, privateKey, networkConfig),
+		);
+		gasWalletSettleQueue = result.catch(() => {});
+		return result;
 	}
+
 	const facilitatorUrl = config.facilitatorUrl ?? networkConfig.facilitatorUrl;
 	return settleViaFacilitator(paymentPayload, facilitatorUrl);
 }

--- a/src/integrations/settlement.ts
+++ b/src/integrations/settlement.ts
@@ -122,7 +122,7 @@ export function buildDiscoveryResponse(
 	config: SellerConfig,
 	networkConfig: NetworkConfig,
 ): X402PaymentRequiredResponse {
-	const basePath = config.basePath ?? "/a2a";
+	const _basePath = config.basePath ?? "/a2a";
 	const baseUrl = config.agentUrl.replace(/\/$/, "");
 	const resourceUrl = `${baseUrl}/x402/access`;
 
@@ -183,7 +183,10 @@ export function buildDiscoveryResponse(
 						accessToken: { type: "string", description: "JWT token for API access" },
 						tokenType: { type: "string", description: "Token type (usually 'Bearer')" },
 						expiresAt: { type: "string", description: "ISO 8601 expiration timestamp" },
-						resourceEndpoint: { type: "string", description: "URL to access the protected resource" },
+						resourceEndpoint: {
+							type: "string",
+							description: "URL to access the protected resource",
+						},
 						txHash: { type: "string", description: "On-chain transaction hash" },
 						explorerUrl: { type: "string", description: "Blockchain explorer URL" },
 					},

--- a/src/integrations/x402-http-middleware.ts
+++ b/src/integrations/x402-http-middleware.ts
@@ -22,12 +22,13 @@ const X_A2A_EXTENSIONS_HEADER = "x-a2a-extensions";
 
 // Re-export shared settlement utilities so callers can import from a single place
 export {
-	buildHttpPaymentRequirements,
 	buildDiscoveryResponse,
+	buildHttpPaymentRequirements,
 	decodePaymentSignature,
 	settlePayment,
+	settleViaFacilitator,
+	settleViaGasWallet,
 } from "./settlement.js";
-export { settleViaFacilitator, settleViaGasWallet } from "./settlement.js";
 
 /**
  * Express middleware that intercepts AccessRequest calls on the JSON-RPC endpoint

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,7 +1,7 @@
 import type { AccessRequest, ChallengeRecord, SellerConfig } from "../types/index.js";
 
 const DEFAULT_WALLET = `0x${"ab".repeat(20)}` as `0x${string}`;
-const DEFAULT_SECRET = "a-very-long-secret-that-is-at-least-32-characters!";
+const _DEFAULT_SECRET = "a-very-long-secret-that-is-at-least-32-characters!";
 
 /**
  * Create a test ChallengeRecord with sensible defaults.

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,3 +1,3 @@
+export { makeAccessRequest, makeChallengeRecord, makeSellerConfig } from "./fixtures.js";
 export { MockPaymentAdapter } from "./mock-adapter.js";
-export { makeChallengeRecord, makeSellerConfig, makeAccessRequest } from "./fixtures.js";
 export { TestChallengeStore, TestSeenTxStore } from "./stores.js";

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -40,6 +40,21 @@ export type ProductTier = {
 
 export type ResourceVerifier = (resourceId: string, tierId: string) => Promise<boolean>;
 
+/**
+ * Minimal Redis interface required for distributed gas wallet lock.
+ * Satisfied by any ioredis client instance.
+ */
+export type IRedisLockClient = {
+	set(
+		key: string,
+		value: string,
+		nx: "NX",
+		px: "PX",
+		ttlMs: number,
+	): Promise<string | null>;
+	eval(script: string, numkeys: number, ...args: string[]): Promise<unknown>;
+};
+
 export type SellerConfig = {
 	// Identity
 	readonly agentName: string;
@@ -81,4 +96,13 @@ export type SellerConfig = {
 	// Settlement strategy (optional — defaults to facilitatorUrl mode)
 	readonly gasWalletPrivateKey?: `0x${string}`; // enables gas wallet mode (self-contained settlement)
 	readonly facilitatorUrl?: string; // override default facilitatorUrl from CHAIN_CONFIGS
+
+	/**
+	 * Redis client for distributed gas wallet settlement locking.
+	 * When provided alongside gasWalletPrivateKey, concurrent settlement
+	 * requests across multiple instances are serialized via a Redis lock,
+	 * preventing gas wallet nonce conflicts.
+	 * When absent, falls back to an in-process serial queue (single-instance only).
+	 */
+	readonly redis?: IRedisLockClient;
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -45,13 +45,7 @@ export type ResourceVerifier = (resourceId: string, tierId: string) => Promise<b
  * Satisfied by any ioredis client instance.
  */
 export type IRedisLockClient = {
-	set(
-		key: string,
-		value: string,
-		nx: "NX",
-		px: "PX",
-		ttlMs: number,
-	): Promise<string | null>;
+	set(key: string, value: string, nx: "NX", px: "PX", ttlMs: number): Promise<string | null>;
 	eval(script: string, numkeys: number, ...args: string[]): Promise<unknown>;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,62 +1,58 @@
 export type {
+	ChallengePayload,
+	IPaymentAdapter,
+	IssueChallengeParams,
+	VerificationErrorCode,
+	VerificationResult,
+	VerifyProofParams,
+} from "./adapter.js";
+export type {
+	AgentCard,
+	AgentExtension,
+	AgentSkill,
+	AgentSkillInputSchema,
 	PaymentProtocol,
 	SkillPricing,
-	AgentSkillInputSchema,
-	AgentSkill,
-	AgentExtension,
-	AgentCard,
 } from "./agent-card.js";
 
 export type {
-	PaymentRequirements,
-	ResourceInfo,
-	AgentGateExtension,
-	X402PaymentRequiredResponse,
-	X402PaymentPayload,
-	EIP3009Authorization,
-	X402SettleResponse,
-	X402PaymentStatus,
-	FacilitatorVerifyResponse,
-} from "./x402-extension.js";
-
-export {
-	X402_EXTENSION_URI,
-	X402_METADATA_KEYS,
-	CHAIN_ID_TO_NETWORK,
-	NETWORK_TO_CHAIN_ID,
-} from "./x402-extension.js";
-
-export type {
-	ChallengeState,
-	AccessRequest,
-	X402Challenge,
-	PaymentProof,
 	AccessGrant,
+	AccessRequest,
 	ChallengeRecord,
+	ChallengeState,
+	PaymentProof,
+	X402Challenge,
 } from "./challenge.js";
 
 export type {
-	NetworkName,
+	IssueTokenParams,
 	NetworkConfig,
+	NetworkName,
 	ProductTier,
 	ResourceVerifier,
 	SellerConfig,
 	TokenIssuanceResult,
-	IssueTokenParams,
 } from "./config.js";
 
 export { CHAIN_CONFIGS, USDC_DECIMALS } from "./config-shared.js";
-
-export type {
-	IssueChallengeParams,
-	ChallengePayload,
-	VerifyProofParams,
-	VerificationResult,
-	VerificationErrorCode,
-} from "./adapter.js";
-export type { IPaymentAdapter } from "./adapter.js";
-
-export type { IChallengeStore, ISeenTxStore, ChallengeTransitionUpdates } from "./storage.js";
-
-export { AgentGateError } from "./errors.js";
 export type { AgentGateErrorCode } from "./errors.js";
+export { AgentGateError } from "./errors.js";
+
+export type { ChallengeTransitionUpdates, IChallengeStore, ISeenTxStore } from "./storage.js";
+export type {
+	AgentGateExtension,
+	EIP3009Authorization,
+	FacilitatorVerifyResponse,
+	PaymentRequirements,
+	ResourceInfo,
+	X402PaymentPayload,
+	X402PaymentRequiredResponse,
+	X402PaymentStatus,
+	X402SettleResponse,
+} from "./x402-extension.js";
+export {
+	CHAIN_ID_TO_NETWORK,
+	NETWORK_TO_CHAIN_ID,
+	X402_EXTENSION_URI,
+	X402_METADATA_KEYS,
+} from "./x402-extension.js";

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,4 +1,4 @@
-import { type JWTPayload, importSPKI, jwtVerify } from "jose";
+import { importSPKI, type JWTPayload, jwtVerify } from "jose";
 
 export type AccessTokenPayload = JWTPayload & {
 	readonly sub: string; // requestId


### PR DESCRIPTION
## Summary

- Adds a full e2e test suite (17 scenarios) that spins up the real AgentGate Docker container against Base Sepolia testnet
- Fixes refund transactions to use the gas wallet for gas via EIP-3009 `transferWithAuthorization` — AGENTGATE wallet no longer needs ETH
- Fixes a Redis atomicity bug where the `agentgate:paid` sorted set could get out of sync with the challenge hash on process crash
- Adds distributed Redis locking for gas wallet settlement to prevent nonce conflicts across multiple instances

## What's tested

| Scenario | What it validates |
|---|---|
| Agent Card | Discovery document shape and pricing |
| Happy Path | Full purchase → JWT → protected API call |
| Challenge Timeout | Idempotency resets after TTL expiry |
| Double Spend | Same EIP-3009 nonce rejected on second challenge |
| Wrong Amount | Underpayment rejected before on-chain call |
| Wrong Recipient | Payment to wrong address rejected |
| Invalid Tier | Unknown tier fails before issuing payment requirements |
| Idempotent Challenge | Same requestId returns same challengeId |
| Token Issuance Failure | PAID record survives backend 500 (refund cron can pick it up) |
| Refund Success | Cron refunds PAID record via EIP-3009, transitions to REFUNDED |
| Refund Failure | Empty AGENTGATE wallet transitions record to REFUND_FAILED |
| Concurrent Purchases | Two simultaneous buyers both succeed, no nonce conflict |

## Fixes included

**`fix/refundWallet` (merged):** `processRefunds` now passes `gasWalletPrivateKey` to `sendUsdc`, which uses EIP-3009 `transferWithAuthorization` — AGENTGATE wallet signs the authorization off-chain, gas wallet submits on-chain. AGENTGATE wallet needs USDC but no ETH.

**Redis atomicity:** `ZADD`/`ZREM` on `agentgate:paid` sorted set moved inside the Lua transition script. Previously a process crash between the Lua commit and the separate `ZADD` would leave a PAID record permanently outside the sorted set, making it invisible to the refund cron.

**Settlement locking:** Concurrent gas wallet settlements are serialized via a Redis `SET NX` lock (`agentgate:settle-lock:{prefix}`) when Redis is available. Falls back to an in-process promise queue for single-instance deployments without Redis.

## CI

E2e workflow runs on every PR to `main`, skipping PRs that only touch `.md` or `.claude` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)