### PR TITLE
feat(docker): compose profiles for managed infra and adaptive setup UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,18 @@ There are two ways to configure Standalone mode:
 Just start the container with no environment variables — Key0 boots into **Setup Mode** and serves a browser-based configuration wizard:
 
 ```bash
-docker compose -f docker/docker-compose.yml up
+docker compose -f docker/docker-compose.yml --profile full up
 # Open http://localhost:3000 → redirects to /setup
 ```
+
+Docker Compose profiles control which infrastructure services are bundled:
+
+| Profile | What starts |
+|---|---|
+| *(none)* | Key0 only — bring your own Redis + Postgres via env vars |
+| `--profile redis` | Key0 + managed Redis |
+| `--profile postgres` | Key0 + managed Postgres (still needs Redis externally) |
+| `--profile full` | Key0 + managed Redis + managed Postgres (batteries included) |
 
 The Setup UI lets you configure everything visually: wallet address, network, pricing plans, token issuance API, settlement, and refund settings. When you submit, the server writes the config and restarts automatically.
 
@@ -96,7 +105,7 @@ docker run \
 ```bash
 cp docker/.env.example docker/.env
 # Edit docker/.env: set KEY0_WALLET_ADDRESS and ISSUE_TOKEN_API
-docker compose -f docker/docker-compose.yml up
+docker compose -f docker/docker-compose.yml --profile redis up
 ```
 
 > Even with env vars pre-configured, the Setup UI is always available at `/setup` for reconfiguration.
@@ -132,7 +141,10 @@ Build from source: `docker build -t key0ai/key0 .`
 | `BACKEND_AUTH_STRATEGY` | | `none` | How Key0 authenticates with `ISSUE_TOKEN_API` — `none`, `shared-secret`, or `jwt` |
 | `ISSUE_TOKEN_API_SECRET` | | — | Secret for `ISSUE_TOKEN_API` auth — Bearer token (shared-secret) or JWT signing key (jwt). Only used when `BACKEND_AUTH_STRATEGY` is not `none` |
 | `MCP_ENABLED` | | `false` | When `true`, mounts MCP routes (`/.well-known/mcp.json` + `POST /mcp`) exposing `discover_plans` and `request_access` tools |
-| `REDIS_URL` | ✅ | — | Redis connection URL — required for multi-replica deployments and the BullMQ refund cron |
+| `STORAGE_BACKEND` | | `redis` | Storage backend — `redis` or `postgres` |
+| `DATABASE_URL` | | — | PostgreSQL connection URL — required when `STORAGE_BACKEND=postgres` |
+| `REDIS_URL` | ✅ | — | Redis connection URL — required for challenge state (or BullMQ refund cron when using Postgres) |
+| `KEY0_MANAGED_INFRA` | | — | Comma-separated list of infra managed by Docker Compose profiles (e.g. `redis,postgres`) — set automatically by profile launch commands |
 | `GAS_WALLET_PRIVATE_KEY` | | — | Private key of a wallet holding ETH on Base — enables self-contained settlement without a CDP facilitator |
 | `KEY0_WALLET_PRIVATE_KEY` | | — | Private key of `KEY0_WALLET_ADDRESS` — required for the refund cron to send USDC back to payers |
 | `REFUND_INTERVAL_MS` | | `60000` | How often the refund cron runs (ms) — only active when `KEY0_WALLET_PRIVATE_KEY` is set |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Just start the container with no environment variables — Key0 boots into **Set
 ```bash
 docker compose -f docker/docker-compose.yml --profile full up
 # Open http://localhost:3000 → redirects to /setup
+# Managed infra (Redis, Postgres) is auto-detected at startup — no extra env vars needed.
 ```
 
 Docker Compose profiles control which infrastructure services are bundled:
@@ -144,7 +145,7 @@ Build from source: `docker build -t key0ai/key0 .`
 | `STORAGE_BACKEND` | | `redis` | Storage backend — `redis` or `postgres` |
 | `DATABASE_URL` | | — | PostgreSQL connection URL — required when `STORAGE_BACKEND=postgres` |
 | `REDIS_URL` | ✅ | — | Redis connection URL — required for challenge state (or BullMQ refund cron when using Postgres) |
-| `KEY0_MANAGED_INFRA` | | — | Comma-separated list of infra managed by Docker Compose profiles (e.g. `redis,postgres`) — set automatically by profile launch commands |
+| `KEY0_MANAGED_INFRA` | | — | Optional comma-separated list of compose-managed infra (e.g. `redis,postgres`). Auto-detected at startup via DNS; only needed as an explicit override |
 | `GAS_WALLET_PRIVATE_KEY` | | — | Private key of a wallet holding ETH on Base — enables self-contained settlement without a CDP facilitator |
 | `KEY0_WALLET_PRIVATE_KEY` | | — | Private key of `KEY0_WALLET_ADDRESS` — required for the refund cron to send USDC back to payers |
 | `REFUND_INTERVAL_MS` | | `60000` | How often the refund cron runs (ms) — only active when `KEY0_WALLET_PRIVATE_KEY` is set |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,31 @@
+# Key0 Docker Compose
+#
+# Profiles
+#   (no profile)          key0 only — bring your own Redis + Postgres via env vars
+#   --profile redis       key0 + managed Redis
+#   --profile postgres    key0 + managed Postgres (still requires Redis)
+#   --profile full        key0 + managed Redis + managed Postgres (batteries included)
+#
+# Quick start (batteries included):
+#   KEY0_MANAGED_INFRA=redis,postgres docker compose --profile full up
+#
+# Managed Redis, external Postgres:
+#   KEY0_MANAGED_INFRA=redis DATABASE_URL=postgresql://... docker compose --profile redis up
+#
+# All external (e.g. docker run or your own infra):
+#   docker run -p 3000:3000 -e REDIS_URL=... -e DATABASE_URL=... key0ai/key0:latest
+
 services:
   key0:
-    build: ..
+    image: key0ai/key0:latest
     ports:
       - "${PORT:-3000}:${PORT:-3000}"
     environment:
       - PORT=${PORT:-3000}
+      # Set by the profile launch commands above so the Setup UI knows which
+      # services are managed (comma-separated: redis,postgres)
+      - KEY0_MANAGED_INFRA=${KEY0_MANAGED_INFRA:-}
+      # Default URLs point to the compose service names; overridden by .env for external infra
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}
       - DATABASE_URL=${DATABASE_URL:-postgresql://key0:key0@postgres:5432/key0}
     env_file:
@@ -17,11 +38,14 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+        required: false
       postgres:
         condition: service_healthy
+        required: false
 
   redis:
     image: redis:7-alpine
+    profiles: [redis, full]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -32,12 +56,13 @@ services:
 
   postgres:
     image: postgres:16-alpine
+    profiles: [postgres, full]
     environment:
-      POSTGRES_USER: key0
-      POSTGRES_PASSWORD: key0
-      POSTGRES_DB: key0
+      POSTGRES_USER: ${POSTGRES_USER:-key0}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-key0}
+      POSTGRES_DB: ${POSTGRES_DB:-key0}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U key0 -d key0"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-key0} -d ${POSTGRES_DB:-key0}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,13 +7,16 @@
 #   --profile full        key0 + managed Redis + managed Postgres (batteries included)
 #
 # Quick start (batteries included):
-#   KEY0_MANAGED_INFRA=redis,postgres docker compose --profile full up
+#   docker compose --profile full up
 #
 # Managed Redis, external Postgres:
-#   KEY0_MANAGED_INFRA=redis DATABASE_URL=postgresql://... docker compose --profile redis up
+#   docker compose --profile redis up   # set DATABASE_URL in .env
 #
 # All external (e.g. docker run or your own infra):
 #   docker run -p 3000:3000 -e REDIS_URL=... -e DATABASE_URL=... key0ai/key0:latest
+#
+# Note: Managed infra is auto-detected at startup via DNS resolution.
+# KEY0_MANAGED_INFRA is optional — only needed as an explicit override.
 
 services:
   key0:
@@ -22,8 +25,7 @@ services:
       - "${PORT:-3000}:${PORT:-3000}"
     environment:
       - PORT=${PORT:-3000}
-      # Set by the profile launch commands above so the Setup UI knows which
-      # services are managed (comma-separated: redis,postgres)
+      # Optional explicit override — managed infra is auto-detected via DNS at startup
       - KEY0_MANAGED_INFRA=${KEY0_MANAGED_INFRA:-}
       # Default URLs point to the compose service names; overridden by .env for external infra
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -18,7 +18,35 @@ const WALLET_ADDRESS = process.env.KEY0_WALLET_ADDRESS;
 const ISSUE_TOKEN_API = process.env.ISSUE_TOKEN_API;
 const REDIS_URL = process.env.REDIS_URL;
 
-const isConfigured = Boolean(WALLET_ADDRESS && ISSUE_TOKEN_API && REDIS_URL);
+// Parse which infra services are managed by Docker Compose profiles
+// e.g. KEY0_MANAGED_INFRA=redis,postgres when using --profile full
+const MANAGED_INFRA = (process.env.KEY0_MANAGED_INFRA ?? "")
+	.split(",")
+	.map((s) => s.trim().toLowerCase())
+	.filter(Boolean);
+
+// A URL is "usable" only when it's a real user-supplied external URL,
+// OR the matching compose service is actually running (listed in MANAGED_INFRA).
+// Compose-default internal hostnames (redis://redis:*, *@postgres:*) are treated
+// as placeholder — they'll cause ENOTFOUND if the profile service isn't running.
+const redisUsable = Boolean(
+	REDIS_URL &&
+		(MANAGED_INFRA.includes("redis") || !REDIS_URL.startsWith("redis://redis:")),
+);
+const postgresUrlUsable = Boolean(
+	process.env.DATABASE_URL &&
+		(MANAGED_INFRA.includes("postgres") ||
+			!/postgresql:\/\/[^@]+@postgres:/.test(process.env.DATABASE_URL)),
+);
+const STORAGE_BACKEND_EARLY = (process.env.STORAGE_BACKEND ?? "redis") as "redis" | "postgres";
+
+const isConfigured = Boolean(
+	WALLET_ADDRESS &&
+		ISSUE_TOKEN_API &&
+		(STORAGE_BACKEND_EARLY === "postgres"
+			? postgresUrlUsable && (redisUsable || MANAGED_INFRA.includes("redis"))
+			: redisUsable),
+);
 
 const app = express();
 app.use(express.json());
@@ -56,8 +84,16 @@ app.get("/api/setup/status", (_req, res) => {
 		// ignore — UI will fall back to its default
 	}
 
+	// Parse which infra services are managed by Docker Compose (comma-separated)
+	// e.g. KEY0_MANAGED_INFRA=redis,postgres when using --profile full
+	const managedInfra = (process.env.KEY0_MANAGED_INFRA ?? "")
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter(Boolean);
+
 	res.json({
 		configured: isConfigured,
+		managedInfra,
 		config: {
 			walletAddress: WALLET_ADDRESS ?? "",
 			issueTokenApi: ISSUE_TOKEN_API ?? "",

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -59,9 +59,7 @@ const STORAGE_BACKEND_EARLY = (process.env.STORAGE_BACKEND ?? "redis") as "redis
 const isConfigured = Boolean(
 	WALLET_ADDRESS &&
 		ISSUE_TOKEN_API &&
-		(STORAGE_BACKEND_EARLY === "postgres"
-			? postgresUrlUsable && redisUsable
-			: redisUsable),
+		(STORAGE_BACKEND_EARLY === "postgres" ? postgresUrlUsable && redisUsable : redisUsable),
 );
 
 const app = express();

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -30,8 +30,7 @@ const MANAGED_INFRA = (process.env.KEY0_MANAGED_INFRA ?? "")
 // Compose-default internal hostnames (redis://redis:*, *@postgres:*) are treated
 // as placeholder — they'll cause ENOTFOUND if the profile service isn't running.
 const redisUsable = Boolean(
-	REDIS_URL &&
-		(MANAGED_INFRA.includes("redis") || !REDIS_URL.startsWith("redis://redis:")),
+	REDIS_URL && (MANAGED_INFRA.includes("redis") || !REDIS_URL.startsWith("redis://redis:")),
 );
 const postgresUrlUsable = Boolean(
 	process.env.DATABASE_URL &&

--- a/docker/server.ts
+++ b/docker/server.ts
@@ -8,6 +8,7 @@
  * See docker/.env.example for the full list of env vars.
  */
 
+import { lookup } from "node:dns/promises";
 import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -18,32 +19,48 @@ const WALLET_ADDRESS = process.env.KEY0_WALLET_ADDRESS;
 const ISSUE_TOKEN_API = process.env.ISSUE_TOKEN_API;
 const REDIS_URL = process.env.REDIS_URL;
 
-// Parse which infra services are managed by Docker Compose profiles
-// e.g. KEY0_MANAGED_INFRA=redis,postgres when using --profile full
-const MANAGED_INFRA = (process.env.KEY0_MANAGED_INFRA ?? "")
+// Optional explicit hint from the user (e.g. KEY0_MANAGED_INFRA=redis,postgres).
+// No longer required — managed infra is auto-detected via DNS at startup.
+const MANAGED_INFRA_EXPLICIT = (process.env.KEY0_MANAGED_INFRA ?? "")
 	.split(",")
 	.map((s) => s.trim().toLowerCase())
 	.filter(Boolean);
 
-// A URL is "usable" only when it's a real user-supplied external URL,
-// OR the matching compose service is actually running (listed in MANAGED_INFRA).
-// Compose-default internal hostnames (redis://redis:*, *@postgres:*) are treated
-// as placeholder — they'll cause ENOTFOUND if the profile service isn't running.
-const redisUsable = Boolean(
-	REDIS_URL && (MANAGED_INFRA.includes("redis") || !REDIS_URL.startsWith("redis://redis:")),
-);
-const postgresUrlUsable = Boolean(
-	process.env.DATABASE_URL &&
-		(MANAGED_INFRA.includes("postgres") ||
-			!/postgresql:\/\/[^@]+@postgres:/.test(process.env.DATABASE_URL)),
-);
+// ─── Auto-detect infrastructure availability via DNS ─────────────────────
+//
+// Instead of relying on a user-supplied env var to know whether compose-internal
+// services (redis, postgres) are running, we do a quick DNS lookup at startup.
+//   - hostname resolves  → service is reachable → URL is usable
+//   - hostname fails     → service not running  → enter setup mode
+//
+// This works transparently for all deployment scenarios:
+//   docker compose --profile full up   → redis/postgres resolve inside compose network
+//   docker compose up (no profile)     → hostnames don't resolve → setup mode
+//   docker run -e REDIS_URL=redis://external:6379  → external hostname resolves
+
+async function isHostReachable(url: string | undefined, timeoutMs = 3000): Promise<boolean> {
+	if (!url) return false;
+	try {
+		const hostname = new URL(url).hostname;
+		await Promise.race([
+			lookup(hostname),
+			new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), timeoutMs)),
+		]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const redisUsable = await isHostReachable(REDIS_URL);
+const postgresUrlUsable = await isHostReachable(process.env.DATABASE_URL);
 const STORAGE_BACKEND_EARLY = (process.env.STORAGE_BACKEND ?? "redis") as "redis" | "postgres";
 
 const isConfigured = Boolean(
 	WALLET_ADDRESS &&
 		ISSUE_TOKEN_API &&
 		(STORAGE_BACKEND_EARLY === "postgres"
-			? postgresUrlUsable && (redisUsable || MANAGED_INFRA.includes("redis"))
+			? postgresUrlUsable && redisUsable
 			: redisUsable),
 );
 
@@ -83,12 +100,22 @@ app.get("/api/setup/status", (_req, res) => {
 		// ignore — UI will fall back to its default
 	}
 
-	// Parse which infra services are managed by Docker Compose (comma-separated)
-	// e.g. KEY0_MANAGED_INFRA=redis,postgres when using --profile full
-	const managedInfra = (process.env.KEY0_MANAGED_INFRA ?? "")
-		.split(",")
-		.map((s) => s.trim().toLowerCase())
-		.filter(Boolean);
+	// Auto-detect which infra is managed by Docker Compose:
+	// A service is "managed" if its URL points to a compose-internal hostname
+	// (e.g. redis, postgres) AND that hostname actually resolved at startup.
+	const autoManaged: string[] = [];
+	if (redisUsable && REDIS_URL && /^redis:\/\/redis[^.]*:/.test(REDIS_URL)) {
+		autoManaged.push("redis");
+	}
+	if (
+		postgresUrlUsable &&
+		process.env.DATABASE_URL &&
+		/postgresql?:\/\/[^@]+@postgres[^.]*:/.test(process.env.DATABASE_URL)
+	) {
+		autoManaged.push("postgres");
+	}
+	// Merge explicit KEY0_MANAGED_INFRA (if set) with auto-detected
+	const managedInfra = [...new Set([...MANAGED_INFRA_EXPLICIT, ...autoManaged])];
 
 	res.json({
 		configured: isConfigured,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,50 +31,50 @@ export default function App() {
 				const managed: string[] = data.managedInfra ?? [];
 				setManagedInfra(managed);
 
-			if (data.config) {
-				// Compose-default internal hostnames are placeholders — only valid if
-				// the matching service is actually managed (profile running).
-				// If not managed, treat them as unset so the user fills real URLs.
-				const resolveUrl = (
-					url: string | undefined,
-					svc: string,
-					composePlaceholder: string,
-				): string => {
-					if (managed.includes(svc)) {
-						// Service is managed — pre-fill with the internal compose default
-						return url || composePlaceholder;
-					}
-					// Service is external — clear the compose placeholder, keep real URLs
-					return !url || url === composePlaceholder ? "" : url;
-				};
+				if (data.config) {
+					// Compose-default internal hostnames are placeholders — only valid if
+					// the matching service is actually managed (profile running).
+					// If not managed, treat them as unset so the user fills real URLs.
+					const resolveUrl = (
+						url: string | undefined,
+						svc: string,
+						composePlaceholder: string,
+					): string => {
+						if (managed.includes(svc)) {
+							// Service is managed — pre-fill with the internal compose default
+							return url || composePlaceholder;
+						}
+						// Service is external — clear the compose placeholder, keep real URLs
+						return !url || url === composePlaceholder ? "" : url;
+					};
 
-				setConfig((prev) => ({
-					...prev,
-					walletAddress: data.config.walletAddress ?? "",
-					issueTokenApi: data.config.issueTokenApi ?? "",
-					network: data.config.network ?? "testnet",
-					storageBackend: data.config.storageBackend ?? "redis",
-					redisUrl: resolveUrl(data.config.redisUrl, "redis", "redis://redis:6379"),
-					databaseUrl: resolveUrl(
-						data.config.databaseUrl,
-						"postgres",
-						"postgresql://key0:key0@postgres:5432/key0",
-					),
-					port: data.config.port ?? "3000",
-					basePath: data.config.basePath ?? "/a2a",
-					agentUrl: data.config.agentUrl ?? "",
-					providerName: data.config.providerName ?? "",
-					providerUrl: data.config.providerUrl ?? "",
-					...(data.config.plans?.length > 0 ? { plans: data.config.plans } : {}),
-					challengeTtlSeconds: data.config.challengeTtlSeconds ?? "900",
-					mcpEnabled: data.config.mcpEnabled ?? true,
-					backendAuthStrategy: data.config.backendAuthStrategy ?? "none",
-					issueTokenApiSecret: data.config.issueTokenApiSecret ?? "",
-					gasWalletPrivateKey: data.config.gasWalletPrivateKey ?? "",
-					walletPrivateKey: data.config.walletPrivateKey ?? "",
-					refundIntervalMs: data.config.refundIntervalMs ?? "60000",
-					refundMinAgeMs: data.config.refundMinAgeMs ?? "300000",
-				}));
+					setConfig((prev) => ({
+						...prev,
+						walletAddress: data.config.walletAddress ?? "",
+						issueTokenApi: data.config.issueTokenApi ?? "",
+						network: data.config.network ?? "testnet",
+						storageBackend: data.config.storageBackend ?? "redis",
+						redisUrl: resolveUrl(data.config.redisUrl, "redis", "redis://redis:6379"),
+						databaseUrl: resolveUrl(
+							data.config.databaseUrl,
+							"postgres",
+							"postgresql://key0:key0@postgres:5432/key0",
+						),
+						port: data.config.port ?? "3000",
+						basePath: data.config.basePath ?? "/a2a",
+						agentUrl: data.config.agentUrl ?? "",
+						providerName: data.config.providerName ?? "",
+						providerUrl: data.config.providerUrl ?? "",
+						...(data.config.plans?.length > 0 ? { plans: data.config.plans } : {}),
+						challengeTtlSeconds: data.config.challengeTtlSeconds ?? "900",
+						mcpEnabled: data.config.mcpEnabled ?? true,
+						backendAuthStrategy: data.config.backendAuthStrategy ?? "none",
+						issueTokenApiSecret: data.config.issueTokenApiSecret ?? "",
+						gasWalletPrivateKey: data.config.gasWalletPrivateKey ?? "",
+						walletPrivateKey: data.config.walletPrivateKey ?? "",
+						refundIntervalMs: data.config.refundIntervalMs ?? "60000",
+						refundMinAgeMs: data.config.refundMinAgeMs ?? "300000",
+					}));
 				}
 			})
 			.catch(() => {
@@ -380,49 +380,11 @@ export default function App() {
 								</Select>
 							</Field>
 
-						{config.storageBackend === "redis" && (
-							<Field
-								label="Redis URL"
-								required={!isManaged("redis")}
-								hint={isManaged("redis") ? "Managed by Docker Compose" : undefined}
-							>
-								<Input
-									value={config.redisUrl}
-									onChange={(e) => set("redisUrl", e.target.value)}
-									placeholder="redis://redis:6379"
-									disabled={isManaged("redis")}
-									className={isManaged("redis") ? "opacity-60 cursor-not-allowed" : ""}
-								/>
-							</Field>
-						)}
-
-						{config.storageBackend === "postgres" && (
-							<>
-								<Field
-									label="Database URL"
-									required={!isManaged("postgres")}
-									hint={
-										isManaged("postgres")
-											? "Managed by Docker Compose"
-											: "PostgreSQL connection string"
-									}
-								>
-									<Input
-										value={config.databaseUrl}
-										onChange={(e) => set("databaseUrl", e.target.value)}
-										placeholder="postgresql://user:pass@host:5432/db"
-										spellCheck={false}
-										disabled={isManaged("postgres")}
-										className={isManaged("postgres") ? "opacity-60 cursor-not-allowed" : ""}
-									/>
-								</Field>
+							{config.storageBackend === "redis" && (
 								<Field
 									label="Redis URL"
-									hint={
-										isManaged("redis")
-											? "Managed by Docker Compose"
-											: "Still required for BullMQ refund cron queue"
-									}
+									required={!isManaged("redis")}
+									hint={isManaged("redis") ? "Managed by Docker Compose" : undefined}
 								>
 									<Input
 										value={config.redisUrl}
@@ -432,8 +394,46 @@ export default function App() {
 										className={isManaged("redis") ? "opacity-60 cursor-not-allowed" : ""}
 									/>
 								</Field>
-							</>
-						)}
+							)}
+
+							{config.storageBackend === "postgres" && (
+								<>
+									<Field
+										label="Database URL"
+										required={!isManaged("postgres")}
+										hint={
+											isManaged("postgres")
+												? "Managed by Docker Compose"
+												: "PostgreSQL connection string"
+										}
+									>
+										<Input
+											value={config.databaseUrl}
+											onChange={(e) => set("databaseUrl", e.target.value)}
+											placeholder="postgresql://user:pass@host:5432/db"
+											spellCheck={false}
+											disabled={isManaged("postgres")}
+											className={isManaged("postgres") ? "opacity-60 cursor-not-allowed" : ""}
+										/>
+									</Field>
+									<Field
+										label="Redis URL"
+										hint={
+											isManaged("redis")
+												? "Managed by Docker Compose"
+												: "Still required for BullMQ refund cron queue"
+										}
+									>
+										<Input
+											value={config.redisUrl}
+											onChange={(e) => set("redisUrl", e.target.value)}
+											placeholder="redis://redis:6379"
+											disabled={isManaged("redis")}
+											className={isManaged("redis") ? "opacity-60 cursor-not-allowed" : ""}
+										/>
+									</Field>
+								</>
+							)}
 
 							<Field label="Challenge TTL (seconds)" hint="Default: 900 (15 min)">
 								<Input

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,11 +10,15 @@ type ServerStatus = "loading" | "setup" | "running" | "standalone";
 export default function App() {
 	const [config, setConfig] = useState<Config>(defaultConfig);
 	const [serverStatus, setServerStatus] = useState<ServerStatus>("loading");
+	const [managedInfra, setManagedInfra] = useState<string[]>([]);
 	const [saving, setSaving] = useState(false);
 	const [saveMessage, setSaveMessage] = useState<{
 		type: "success" | "error";
 		text: string;
 	} | null>(null);
+
+	// Returns true when the given infra service is bundled by Docker Compose profile
+	const isManaged = (svc: string) => managedInfra.includes(svc);
 
 	// Check if we're running inside Docker (API available) or standalone
 	useEffect(() => {
@@ -22,30 +26,55 @@ export default function App() {
 			.then((r) => r.json())
 			.then((data) => {
 				setServerStatus(data.configured ? "running" : "setup");
-				if (data.config) {
-					setConfig((prev) => ({
-						...prev,
-						walletAddress: data.config.walletAddress ?? "",
-						issueTokenApi: data.config.issueTokenApi ?? "",
-						network: data.config.network ?? "testnet",
-						storageBackend: data.config.storageBackend ?? "redis",
-						redisUrl: data.config.redisUrl ?? "redis://redis:6379",
-						databaseUrl: data.config.databaseUrl ?? "",
-						port: data.config.port ?? "3000",
-						basePath: data.config.basePath ?? "/a2a",
-						agentUrl: data.config.agentUrl ?? "",
-						providerName: data.config.providerName ?? "",
-						providerUrl: data.config.providerUrl ?? "",
-						...(data.config.plans?.length > 0 ? { plans: data.config.plans } : {}),
-						challengeTtlSeconds: data.config.challengeTtlSeconds ?? "900",
-						mcpEnabled: data.config.mcpEnabled ?? true,
-						backendAuthStrategy: data.config.backendAuthStrategy ?? "none",
-						issueTokenApiSecret: data.config.issueTokenApiSecret ?? "",
-						gasWalletPrivateKey: data.config.gasWalletPrivateKey ?? "",
-						walletPrivateKey: data.config.walletPrivateKey ?? "",
-						refundIntervalMs: data.config.refundIntervalMs ?? "60000",
-						refundMinAgeMs: data.config.refundMinAgeMs ?? "300000",
-					}));
+
+				// Track which infra services are managed by compose profiles
+				const managed: string[] = data.managedInfra ?? [];
+				setManagedInfra(managed);
+
+			if (data.config) {
+				// Compose-default internal hostnames are placeholders — only valid if
+				// the matching service is actually managed (profile running).
+				// If not managed, treat them as unset so the user fills real URLs.
+				const resolveUrl = (
+					url: string | undefined,
+					svc: string,
+					composePlaceholder: string,
+				): string => {
+					if (managed.includes(svc)) {
+						// Service is managed — pre-fill with the internal compose default
+						return url || composePlaceholder;
+					}
+					// Service is external — clear the compose placeholder, keep real URLs
+					return !url || url === composePlaceholder ? "" : url;
+				};
+
+				setConfig((prev) => ({
+					...prev,
+					walletAddress: data.config.walletAddress ?? "",
+					issueTokenApi: data.config.issueTokenApi ?? "",
+					network: data.config.network ?? "testnet",
+					storageBackend: data.config.storageBackend ?? "redis",
+					redisUrl: resolveUrl(data.config.redisUrl, "redis", "redis://redis:6379"),
+					databaseUrl: resolveUrl(
+						data.config.databaseUrl,
+						"postgres",
+						"postgresql://key0:key0@postgres:5432/key0",
+					),
+					port: data.config.port ?? "3000",
+					basePath: data.config.basePath ?? "/a2a",
+					agentUrl: data.config.agentUrl ?? "",
+					providerName: data.config.providerName ?? "",
+					providerUrl: data.config.providerUrl ?? "",
+					...(data.config.plans?.length > 0 ? { plans: data.config.plans } : {}),
+					challengeTtlSeconds: data.config.challengeTtlSeconds ?? "900",
+					mcpEnabled: data.config.mcpEnabled ?? true,
+					backendAuthStrategy: data.config.backendAuthStrategy ?? "none",
+					issueTokenApiSecret: data.config.issueTokenApiSecret ?? "",
+					gasWalletPrivateKey: data.config.gasWalletPrivateKey ?? "",
+					walletPrivateKey: data.config.walletPrivateKey ?? "",
+					refundIntervalMs: data.config.refundIntervalMs ?? "60000",
+					refundMinAgeMs: data.config.refundMinAgeMs ?? "300000",
+				}));
 				}
 			})
 			.catch(() => {
@@ -63,8 +92,8 @@ export default function App() {
 		config.walletAddress.length === 42 &&
 		config.issueTokenApi.length > 0 &&
 		(config.storageBackend === "redis"
-			? config.redisUrl.length > 0
-			: config.databaseUrl.length > 0) &&
+			? isManaged("redis") || config.redisUrl.length > 0
+			: isManaged("postgres") || config.databaseUrl.length > 0) &&
 		config.plans.length > 0 &&
 		config.plans.every((p) => p.planId && p.unitAmount);
 
@@ -351,35 +380,60 @@ export default function App() {
 								</Select>
 							</Field>
 
-							{config.storageBackend === "redis" && (
-								<Field label="Redis URL" required>
+						{config.storageBackend === "redis" && (
+							<Field
+								label="Redis URL"
+								required={!isManaged("redis")}
+								hint={isManaged("redis") ? "Managed by Docker Compose" : undefined}
+							>
+								<Input
+									value={config.redisUrl}
+									onChange={(e) => set("redisUrl", e.target.value)}
+									placeholder="redis://redis:6379"
+									disabled={isManaged("redis")}
+									className={isManaged("redis") ? "opacity-60 cursor-not-allowed" : ""}
+								/>
+							</Field>
+						)}
+
+						{config.storageBackend === "postgres" && (
+							<>
+								<Field
+									label="Database URL"
+									required={!isManaged("postgres")}
+									hint={
+										isManaged("postgres")
+											? "Managed by Docker Compose"
+											: "PostgreSQL connection string"
+									}
+								>
+									<Input
+										value={config.databaseUrl}
+										onChange={(e) => set("databaseUrl", e.target.value)}
+										placeholder="postgresql://user:pass@host:5432/db"
+										spellCheck={false}
+										disabled={isManaged("postgres")}
+										className={isManaged("postgres") ? "opacity-60 cursor-not-allowed" : ""}
+									/>
+								</Field>
+								<Field
+									label="Redis URL"
+									hint={
+										isManaged("redis")
+											? "Managed by Docker Compose"
+											: "Still required for BullMQ refund cron queue"
+									}
+								>
 									<Input
 										value={config.redisUrl}
 										onChange={(e) => set("redisUrl", e.target.value)}
 										placeholder="redis://redis:6379"
+										disabled={isManaged("redis")}
+										className={isManaged("redis") ? "opacity-60 cursor-not-allowed" : ""}
 									/>
 								</Field>
-							)}
-
-							{config.storageBackend === "postgres" && (
-								<>
-									<Field label="Database URL" required hint="PostgreSQL connection string">
-										<Input
-											value={config.databaseUrl}
-											onChange={(e) => set("databaseUrl", e.target.value)}
-											placeholder="postgresql://user:pass@host:5432/db"
-											spellCheck={false}
-										/>
-									</Field>
-									<Field label="Redis URL" hint="Still required for BullMQ refund cron queue">
-										<Input
-											value={config.redisUrl}
-											onChange={(e) => set("redisUrl", e.target.value)}
-											placeholder="redis://redis:6379"
-										/>
-									</Field>
-								</>
-							)}
+							</>
+						)}
 
 							<Field label="Challenge TTL (seconds)" hint="Default: 900 (15 min)">
 								<Input

--- a/ui/src/components/OutputPanel.tsx
+++ b/ui/src/components/OutputPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
 	generateAgentCardTerminal,
 	generateDockerCompose,
@@ -117,6 +117,20 @@ export function OutputPanel({ config }: OutputPanelProps) {
 	const [deployTab, setDeployTab] = useState<DeployTab>("env");
 	const [copied, setCopied] = useState(false);
 
+	// Hide "docker run" when compose-managed infra is detected —
+	// internal hostnames only resolve inside the compose network, so
+	// docker run alone can't start the bundled Redis/Postgres services.
+	const hasManagedInfra =
+		config.redisUrl === "redis://redis:6379" ||
+		config.databaseUrl === "postgresql://key0:key0@postgres:5432/key0";
+
+	// Auto-switch away from docker-run when user selects managed infra
+	useEffect(() => {
+		if (hasManagedInfra && deployTab === "docker-run") {
+			setDeployTab("docker-compose");
+		}
+	}, [hasManagedInfra, deployTab]);
+
 	const agentCardBlocks = generateAgentCardTerminal(config);
 	const mcpBlocks = generateMcpTerminal(config);
 
@@ -125,7 +139,7 @@ export function OutputPanel({ config }: OutputPanelProps) {
 		mcp: { label: "MCP" },
 	};
 
-	const deployOutputs: Record<DeployTab, { label: string; content: string; filename?: string }> = {
+	const allDeployOutputs: Record<DeployTab, { label: string; content: string; filename?: string }> = {
 		env: { label: ".env", content: generateEnv(config), filename: ".env" },
 		"docker-run": { label: "docker run", content: generateDockerRun(config) },
 		"docker-compose": {
@@ -134,6 +148,15 @@ export function OutputPanel({ config }: OutputPanelProps) {
 			filename: "docker-compose.yml",
 		},
 	};
+
+	// Filter out docker-run tab when managed infra is in use.
+	// Cast back to Record<DeployTab,…> — safe at runtime because the useEffect
+	// above switches deployTab away from "docker-run" before it can be accessed.
+	const deployOutputs = (
+		hasManagedInfra
+			? (({ "docker-run": _omit, ...rest }) => rest)(allDeployOutputs)
+			: allDeployOutputs
+	) as Record<DeployTab, { label: string; content: string; filename?: string }>;
 
 	const getActiveContent = (): string => {
 		if (group === "deploy") return deployOutputs[deployTab].content;

--- a/ui/src/components/OutputPanel.tsx
+++ b/ui/src/components/OutputPanel.tsx
@@ -139,15 +139,16 @@ export function OutputPanel({ config }: OutputPanelProps) {
 		mcp: { label: "MCP" },
 	};
 
-	const allDeployOutputs: Record<DeployTab, { label: string; content: string; filename?: string }> = {
-		env: { label: ".env", content: generateEnv(config), filename: ".env" },
-		"docker-run": { label: "docker run", content: generateDockerRun(config) },
-		"docker-compose": {
-			label: "docker-compose.yml",
-			content: generateDockerCompose(config),
-			filename: "docker-compose.yml",
-		},
-	};
+	const allDeployOutputs: Record<DeployTab, { label: string; content: string; filename?: string }> =
+		{
+			env: { label: ".env", content: generateEnv(config), filename: ".env" },
+			"docker-run": { label: "docker run", content: generateDockerRun(config) },
+			"docker-compose": {
+				label: "docker-compose.yml",
+				content: generateDockerCompose(config),
+				filename: "docker-compose.yml",
+			},
+		};
 
 	// Filter out docker-run tab when managed infra is in use.
 	// Cast back to Record<DeployTab,…> — safe at runtime because the useEffect

--- a/ui/src/components/OutputPanel.tsx
+++ b/ui/src/components/OutputPanel.tsx
@@ -269,7 +269,7 @@ export function OutputPanel({ config }: OutputPanelProps) {
 					</div>
 				) : (
 					<div className="h-full overflow-auto rounded-inner bg-surface shadow-neu-inset p-4">
-						<pre className="text-xs leading-relaxed text-foreground whitespace-pre-wrap break-all font-mono">
+						<pre className="text-xs leading-relaxed text-foreground whitespace-pre-wrap break-words font-mono">
 							{deployOutputs[deployTab].content}
 						</pre>
 					</div>

--- a/ui/src/generate.ts
+++ b/ui/src/generate.ts
@@ -416,22 +416,13 @@ export function generateEnv(config: Config): string {
 		lines.push(`DATABASE_URL=${config.databaseUrl}`);
 	}
 
-	lines.push(
-		"",
-		_sec("Server"),
-		"",
-		`PORT=${config.port}`,
-	);
+	lines.push("", _sec("Server"), "", `PORT=${config.port}`);
 
 	if (config.basePath && config.basePath !== "/a2a") {
 		lines.push(`BASE_PATH=${config.basePath}`);
 	}
 
-	lines.push(
-		"",
-		_sec("Agent Card"),
-		"",
-	);
+	lines.push("", _sec("Agent Card"), "");
 	lines.push(`AGENT_NAME=${_deriveAgentName(config.providerName)}`);
 	lines.push(`AGENT_DESCRIPTION=${_deriveAgentDescription(config.providerName)}`);
 	lines.push(`AGENT_URL=${config.agentUrl}`);
@@ -446,38 +437,19 @@ export function generateEnv(config: Config): string {
 	// Plans
 	if (config.plans.length > 0) {
 		const plansJson = JSON.stringify(config.plans.map(serializePlan), null, 2);
-		lines.push(
-			"",
-			_sec("Pricing Plans"),
-			"",
-			`PLANS='${plansJson}'`,
-		);
+		lines.push("", _sec("Pricing Plans"), "", `PLANS='${plansJson}'`);
 	}
 
 	if (config.challengeTtlSeconds && config.challengeTtlSeconds !== "900") {
-		lines.push(
-			"",
-			_sec("Challenge"),
-			"",
-			`CHALLENGE_TTL_SECONDS=${config.challengeTtlSeconds}`,
-		);
+		lines.push("", _sec("Challenge"), "", `CHALLENGE_TTL_SECONDS=${config.challengeTtlSeconds}`);
 	}
 
 	if (config.mcpEnabled) {
-		lines.push(
-			"",
-			_sec("MCP"),
-			"",
-			"MCP_ENABLED=true",
-		);
+		lines.push("", _sec("MCP"), "", "MCP_ENABLED=true");
 	}
 
 	if (config.backendAuthStrategy !== "none" || config.issueTokenApiSecret) {
-		lines.push(
-			"",
-			_sec("Token API Auth"),
-			"",
-		);
+		lines.push("", _sec("Token API Auth"), "");
 		if (config.backendAuthStrategy !== "none") {
 			lines.push(`BACKEND_AUTH_STRATEGY=${config.backendAuthStrategy}`);
 		}
@@ -487,21 +459,11 @@ export function generateEnv(config: Config): string {
 	}
 
 	if (config.gasWalletPrivateKey) {
-		lines.push(
-			"",
-			_sec("Settlement"),
-			"",
-			`GAS_WALLET_PRIVATE_KEY=${config.gasWalletPrivateKey}`,
-		);
+		lines.push("", _sec("Settlement"), "", `GAS_WALLET_PRIVATE_KEY=${config.gasWalletPrivateKey}`);
 	}
 
 	if (config.walletPrivateKey) {
-		lines.push(
-			"",
-			_sec("Refund Cron"),
-			"",
-			`KEY0_WALLET_PRIVATE_KEY=${config.walletPrivateKey}`,
-		);
+		lines.push("", _sec("Refund Cron"), "", `KEY0_WALLET_PRIVATE_KEY=${config.walletPrivateKey}`);
 		if (config.refundIntervalMs !== "60000") {
 			lines.push(`REFUND_INTERVAL_MS=${config.refundIntervalMs}`);
 		}
@@ -570,8 +532,7 @@ export function generateDockerCompose(config: Config): string {
 	const managedRedis = !config.redisUrl || config.redisUrl === "redis://redis:6379";
 	const managedPostgres =
 		config.storageBackend === "postgres" &&
-		(!config.databaseUrl ||
-			config.databaseUrl === "postgresql://key0:key0@postgres:5432/key0");
+		(!config.databaseUrl || config.databaseUrl === "postgresql://key0:key0@postgres:5432/key0");
 
 	// Build the KEY0_MANAGED_INFRA value
 	const managedParts: string[] = [];
@@ -651,8 +612,14 @@ export function generateDockerCompose(config: Config): string {
 
 	// depends_on only for managed services
 	const dependsOnEntries: string[] = [];
-	if (managedRedis) dependsOnEntries.push("      redis:\n        condition: service_healthy\n        required: false");
-	if (managedPostgres) dependsOnEntries.push("      postgres:\n        condition: service_healthy\n        required: false");
+	if (managedRedis)
+		dependsOnEntries.push(
+			"      redis:\n        condition: service_healthy\n        required: false",
+		);
+	if (managedPostgres)
+		dependsOnEntries.push(
+			"      postgres:\n        condition: service_healthy\n        required: false",
+		);
 
 	// Profile comment header
 	const profileComment = profileFlag

--- a/ui/src/generate.ts
+++ b/ui/src/generate.ts
@@ -559,21 +559,50 @@ export function generateDockerRun(config: Config): string {
 }
 
 export function generateDockerCompose(config: Config): string {
+	// Determine which infra is "managed" (bundled in compose) vs external
+	const managedRedis = !config.redisUrl || config.redisUrl === "redis://redis:6379";
+	const managedPostgres =
+		config.storageBackend === "postgres" &&
+		(!config.databaseUrl ||
+			config.databaseUrl === "postgresql://key0:key0@postgres:5432/key0");
+
+	// Build the KEY0_MANAGED_INFRA value
+	const managedParts: string[] = [];
+	if (managedRedis) managedParts.push("redis");
+	if (managedPostgres) managedParts.push("postgres");
+	const managedInfraValue = managedParts.join(",");
+
+	// Derive the active profile for the quickstart command
+	const profileFlag =
+		managedRedis && managedPostgres
+			? " --profile full"
+			: managedRedis
+				? " --profile redis"
+				: managedPostgres
+					? " --profile postgres"
+					: "";
+
 	const envVars: Record<string, string> = {
 		KEY0_WALLET_ADDRESS: config.walletAddress,
 		ISSUE_TOKEN_API: config.issueTokenApi,
 		KEY0_NETWORK: config.network,
 		STORAGE_BACKEND: config.storageBackend,
-		REDIS_URL: config.storageBackend === "postgres" ? config.redisUrl : "redis://redis:6379",
+		REDIS_URL: managedRedis ? "redis://redis:6379" : config.redisUrl,
 		PORT: config.port,
 		AGENT_URL: config.agentUrl,
 	};
 
+	if (managedInfraValue) {
+		envVars.KEY0_MANAGED_INFRA = managedInfraValue;
+	}
+
 	envVars.AGENT_NAME = _deriveAgentName(config.providerName);
 	envVars.AGENT_DESCRIPTION = _deriveAgentDescription(config.providerName);
 
-	if (config.storageBackend === "postgres" && config.databaseUrl) {
-		envVars.DATABASE_URL = config.databaseUrl;
+	if (config.storageBackend === "postgres") {
+		envVars.DATABASE_URL = managedPostgres
+			? "postgresql://key0:key0@postgres:5432/key0"
+			: config.databaseUrl;
 	}
 
 	if (config.basePath && config.basePath !== "/a2a") {
@@ -613,46 +642,67 @@ export function generateDockerCompose(config: Config): string {
 		.map(([k, v]) => `      ${k}: "${v}"`)
 		.join("\n");
 
-	const dependsOn = ["redis"];
-	if (config.storageBackend === "postgres") dependsOn.push("postgres");
+	// depends_on only for managed services
+	const dependsOnEntries: string[] = [];
+	if (managedRedis) dependsOnEntries.push("      redis:\n        condition: service_healthy\n        required: false");
+	if (managedPostgres) dependsOnEntries.push("      postgres:\n        condition: service_healthy\n        required: false");
 
-	let services = `services:
+	// Profile comment header
+	const profileComment = profileFlag
+		? `# Start command:\n#   ${managedInfraValue ? `KEY0_MANAGED_INFRA=${managedInfraValue} ` : ""}docker compose${profileFlag} up\n\n`
+		: `# Start command:\n#   docker compose up\n\n`;
+
+	let services = `${profileComment}services:
   key0:
     image: key0ai/key0:latest
     ports:
       - "${config.port}:${config.port}"
     environment:
 ${envLines}
-    depends_on:
-${dependsOn.map((d) => `      - ${d}`).join("\n")}
+    volumes:
+      - key0-config:/app/config
+    extra_hosts:
+      - "host.docker.internal:host-gateway"`;
 
+	if (dependsOnEntries.length > 0) {
+		services += `\n    depends_on:\n${dependsOnEntries.join("\n")}`;
+	}
+
+	if (managedRedis) {
+		services += `\n
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
+    profiles: [redis, full]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     volumes:
-      - redis-data:/data
-`;
+      - redis-data:/data`;
+	}
 
-	if (config.storageBackend === "postgres") {
-		services += `
+	if (managedPostgres) {
+		services += `\n
   postgres:
     image: postgres:16-alpine
-    ports:
-      - "5432:5432"
+    profiles: [postgres, full]
     environment:
       POSTGRES_USER: key0
       POSTGRES_PASSWORD: key0
       POSTGRES_DB: key0
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U key0 -d key0"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
-      - pg-data:/var/lib/postgresql/data
-`;
+      - postgres-data:/var/lib/postgresql/data`;
 	}
 
-	services += `\nvolumes:\n  redis-data:\n`;
-	if (config.storageBackend === "postgres") {
-		services += `  pg-data:\n`;
-	}
+	services += `\n\nvolumes:\n  key0-config:\n`;
+	if (managedRedis) services += `  redis-data:\n`;
+	if (managedPostgres) services += `  postgres-data:\n`;
 
 	return services;
 }

--- a/ui/src/generate.ts
+++ b/ui/src/generate.ts
@@ -384,22 +384,29 @@ function serializePlan(p: Plan) {
 	};
 }
 
+// ── Separator helpers (60-char wide, safe for narrow panels) ─────────────────
+const _HR = "# " + "─".repeat(58);
+const _sec = (name: string): string => {
+	const prefix = `# ── ${name} `;
+	return prefix + "─".repeat(Math.max(0, 60 - prefix.length));
+};
+
 export function generateEnv(config: Config): string {
 	const lines: string[] = [
-		"# ──────────────────────────────────────────────────────────────────────────────",
+		_HR,
 		"# Key0 Docker — Generated Configuration",
-		"# ──────────────────────────────────────────────────────────────────────────────",
+		_HR,
 		"",
-		"# ── Required ──────────────────────────────────────────────────────────────────",
+		_sec("Required"),
 		"",
 		`KEY0_WALLET_ADDRESS=${config.walletAddress}`,
 		`ISSUE_TOKEN_API=${config.issueTokenApi}`,
 		"",
-		"# ── Network ───────────────────────────────────────────────────────────────────",
+		_sec("Network"),
 		"",
 		`KEY0_NETWORK=${config.network}`,
 		"",
-		"# ── Storage ───────────────────────────────────────────────────────────────────",
+		_sec("Storage"),
 		"",
 		`STORAGE_BACKEND=${config.storageBackend}`,
 		`REDIS_URL=${config.redisUrl}`,
@@ -411,7 +418,7 @@ export function generateEnv(config: Config): string {
 
 	lines.push(
 		"",
-		"# ── Server ────────────────────────────────────────────────────────────────────",
+		_sec("Server"),
 		"",
 		`PORT=${config.port}`,
 	);
@@ -422,7 +429,7 @@ export function generateEnv(config: Config): string {
 
 	lines.push(
 		"",
-		"# ── Agent Card ────────────────────────────────────────────────────────────────",
+		_sec("Agent Card"),
 		"",
 	);
 	lines.push(`AGENT_NAME=${_deriveAgentName(config.providerName)}`);
@@ -441,7 +448,7 @@ export function generateEnv(config: Config): string {
 		const plansJson = JSON.stringify(config.plans.map(serializePlan), null, 2);
 		lines.push(
 			"",
-			"# ── Pricing Plans ─────────────────────────────────────────────────────────────",
+			_sec("Pricing Plans"),
 			"",
 			`PLANS='${plansJson}'`,
 		);
@@ -450,7 +457,7 @@ export function generateEnv(config: Config): string {
 	if (config.challengeTtlSeconds && config.challengeTtlSeconds !== "900") {
 		lines.push(
 			"",
-			"# ── Challenge ─────────────────────────────────────────────────────────────────",
+			_sec("Challenge"),
 			"",
 			`CHALLENGE_TTL_SECONDS=${config.challengeTtlSeconds}`,
 		);
@@ -459,7 +466,7 @@ export function generateEnv(config: Config): string {
 	if (config.mcpEnabled) {
 		lines.push(
 			"",
-			"# ── MCP ───────────────────────────────────────────────────────────────────────",
+			_sec("MCP"),
 			"",
 			"MCP_ENABLED=true",
 		);
@@ -468,7 +475,7 @@ export function generateEnv(config: Config): string {
 	if (config.backendAuthStrategy !== "none" || config.issueTokenApiSecret) {
 		lines.push(
 			"",
-			"# ── Token API Auth ────────────────────────────────────────────────────────────",
+			_sec("Token API Auth"),
 			"",
 		);
 		if (config.backendAuthStrategy !== "none") {
@@ -482,7 +489,7 @@ export function generateEnv(config: Config): string {
 	if (config.gasWalletPrivateKey) {
 		lines.push(
 			"",
-			"# ── Settlement ────────────────────────────────────────────────────────────────",
+			_sec("Settlement"),
 			"",
 			`GAS_WALLET_PRIVATE_KEY=${config.gasWalletPrivateKey}`,
 		);
@@ -491,7 +498,7 @@ export function generateEnv(config: Config): string {
 	if (config.walletPrivateKey) {
 		lines.push(
 			"",
-			"# ── Refund Cron ───────────────────────────────────────────────────────────────",
+			_sec("Refund Cron"),
 			"",
 			`KEY0_WALLET_PRIVATE_KEY=${config.walletPrivateKey}`,
 		);


### PR DESCRIPTION
## Summary

Fixes `DNSException: getaddrinfo ENOTFOUND` errors that occurred when running `docker compose up` without profiles. The server was attempting to connect to compose-internal hostnames (`redis://redis:6379`, `postgresql://postgres:5432`) even when those services were not started, causing repeated connection failures.

Introduces Docker Compose profiles (`redis`, `postgres`, `full`) so users can opt into managed infrastructure without manually configuring URLs. The setup UI adapts dynamically — disabling and pre-filling URL inputs for managed services, and hiding the `docker run` output tab when compose-internal infrastructure is in use.

Closes #<issue>

## Changes

- **`docker/docker-compose.yml`**: Switched to `image: key0ai/key0:latest`; added `profiles: [redis, full]` / `profiles: [postgres, full]` to infrastructure services; added `KEY0_MANAGED_INFRA` env var; made `depends_on` entries `required: false`
- **`docker/server.ts`**: Rewrote `isConfigured` logic to treat compose-internal placeholder URLs as unusable unless listed in `KEY0_MANAGED_INFRA`; exposes `managedInfra` on the `/api/setup/status` response
- **`ui/src/App.tsx`**: Added `managedInfra` state; `resolveUrl` helper pre-fills or clears URL fields based on managed status; disables URL inputs with a hint for managed services; skips URL validation for managed services
- **`ui/src/components/OutputPanel.tsx`**: Hides `docker run` tab when compose-managed infra is detected; auto-switches tab; fixed `break-all` → `break-words` on `<pre>` output block to prevent separator lines breaking mid-character
- **`ui/src/generate.ts`**: Added `_HR`/`_sec` helpers producing 60-char separators (down from 80) to eliminate line-wrap artefacts in the output panel; `generateDockerCompose()` now emits `profiles:` blocks and sets `KEY0_MANAGED_INFRA`

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

# Full managed infra (Redis + Postgres bundled)
KEY0_MANAGED_INFRA=redis,postgres docker compose --profile full up -d

# Managed Redis + external Postgres
KEY0_MANAGED_INFRA=redis docker compose --profile redis up -d

# External Redis + managed Postgres
KEY0_MANAGED_INFRA=postgres docker compose --profile postgres up -d

# Fully external (standalone docker run, no compose)
docker run -p 3000:3000 \
  -e REDIS_URL=redis://your-host:6379 \
  key0ai/key0:latest
