### PR TITLE
[WIP] feat: native MPP integration — design spec + compatibility notes

### DIFF
--- a/docs/mpp-compatibility.md
+++ b/docs/mpp-compatibility.md
@@ -1,0 +1,284 @@
+# MPP (Machine Payments Protocol) — Key0 Compatibility Notes
+
+[MPP](https://mpp.dev/overview) is an open, IETF-proposed standard for machine-to-machine payments
+over HTTP. It generalises exactly what x402 does today: a `402 Payment Required` challenge/credential
+round-trip that is payment-rail agnostic.
+
+This document captures everything relevant to Key0 for a potential MPP-compatibility layer or migration.
+
+---
+
+## What MPP Is
+
+MPP standardises HTTP 402 "Payment Required" as a proper authentication scheme, similar to how
+`WWW-Authenticate: Bearer` works for tokens but for payments.
+
+Three parties:
+
+- **Developers / Agents** — clients that discover, pay for, and call APIs without pre-signup.
+- **Services** — APIs that accept payments with zero onboarding friction.
+- **Payment Methods** — pluggable rails (Tempo stablecoins, Stripe, Lightning, custom).
+
+---
+
+## Core Flow (identical in spirit to Key0 x402)
+
+```
+Client  →  GET /resource
+Server  ←  402  WWW-Authenticate: Payment id="…", method="tempo", intent="charge", request="…"
+Client  →  GET /resource  Authorization: Payment <base64url-credential>
+Server  ←  200  Payment-Receipt: <base64url-receipt>
+```
+
+Key0's current x402 flow (`AccessRequest → X402Challenge → PaymentProof → AccessGrant`) maps
+directly onto the MPP Challenge/Credential/Receipt primitives.
+
+---
+
+## Protocol Concepts
+
+### HTTP 402
+
+- Return `402` when a resource requires payment **and** a challenge can be provided.
+- Return `401` only for token auth failures (not payment-related).
+- Return `403` if payment succeeded but policy denies access.
+- Always include `Cache-Control: no-store` on `402` responses.
+- Failed credential validation also returns `402` (fresh challenge + Problem Details RFC 9457 body).
+
+Error types (`https://paymentauth.org/problems/{code}`):
+
+| Code | Meaning |
+|---|---|
+| `payment-required` | Resource requires payment |
+| `payment-insufficient` | Amount too low |
+| `payment-expired` | Challenge or authorization expired |
+| `verification-failed` | Proof invalid |
+| `method-unsupported` | Method not accepted |
+| `malformed-credential` | Invalid credential format |
+| `invalid-challenge` | Challenge ID unknown, expired, or already used |
+
+### Challenges (`WWW-Authenticate: Payment …`)
+
+```
+WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
+                  realm="mpp.dev",
+                  method="tempo",
+                  intent="charge",
+                  expires="2025-01-15T12:05:00Z",
+                  request="<base64url-JSON>"
+```
+
+**Required fields:** `id`, `realm`, `method`, `intent`, `request`
+**Optional:** `expires`, `description`
+
+`request` is a base64url-encoded JSON object with method-specific fields:
+
+```json
+{
+  "amount": "1000",
+  "currency": "usd",
+  "recipient": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+}
+```
+
+**Security:** The `id` must be cryptographically bound (e.g., HMAC) to the challenge parameters
+to prevent clients from reusing an ID with modified payment terms.
+
+**Multiple challenges:** Servers can emit multiple `WWW-Authenticate: Payment` headers (one per
+method), and clients pick one.
+
+**Request body binding:** For POST/PUT/PATCH, servers can include a `digest` param (RFC 9530
+`Content-Digest`) to bind the challenge to the request body, preventing body substitution attacks.
+
+### Credentials (`Authorization: Payment …`)
+
+The credential is a `base64url`-encoded JSON object sent in `Authorization: Payment <token>`:
+
+```json
+{
+  "challenge": { "id": "…", "realm": "…", "method": "tempo", "intent": "charge", "request": "…", "expires": "…" },
+  "source": "0x1234…",
+  "payload": { "signature": "0xabc…" }
+}
+```
+
+Each credential is **single-use** — servers must reject replays.
+
+### Receipts (`Payment-Receipt: …`)
+
+Optional header on `200` responses; base64url-encoded JSON:
+
+```json
+{
+  "challengeId": "qB3wErTyU7iOpAsD9fGhJk",
+  "method": "tempo",
+  "reference": "0xtx789abc…",
+  "settlement": { "amount": "1000", "currency": "usd" },
+  "status": "success",
+  "timestamp": "2025-01-15T12:00:00Z"
+}
+```
+
+Enables auditing, dispute resolution, and reconciliation on the client side.
+
+---
+
+## Transports
+
+### HTTP (primary)
+
+| Direction | Header | Purpose |
+|---|---|---|
+| Server → Client | `WWW-Authenticate: Payment …` | Challenge |
+| Client → Server | `Authorization: Payment …` | Credential |
+| Server → Client | `Payment-Receipt: …` | Receipt |
+
+### MCP / JSON-RPC
+
+MPP encodes the same Challenge/Credential/Receipt primitives in MCP JSON-RPC:
+
+| MPP Concept | MCP Encoding |
+|---|---|
+| Challenge | JSON-RPC error code `-32042` |
+| Credential | `_meta["org.paymentauth/credential"]` in `tools/call` params |
+| Receipt | `_meta["org.paymentauth/receipt"]` in result |
+
+**Challenge (server → agent):**
+```json
+{
+  "jsonrpc": "2.0", "id": 1,
+  "error": {
+    "code": -32042,
+    "message": "Payment Required",
+    "data": {
+      "httpStatus": 402,
+      "challenges": [{ "id": "ch_abc123", "realm": "…", "method": "tempo", "intent": "charge", "request": { … } }]
+    }
+  }
+}
+```
+
+**Credential (agent → server):**
+```json
+{
+  "jsonrpc": "2.0", "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "web-search",
+    "arguments": { "query": "…" },
+    "_meta": { "org.paymentauth/credential": { "challenge": { … }, "source": "0x…", "payload": { … } } }
+  }
+}
+```
+
+Key0 already has a `mcp: true` integration mode. An MPP-native MCP transport would swap the
+custom `structuredContent`/`isError` signalling for the standard `-32042` error code and
+`_meta.org.paymentauth/*` fields.
+
+---
+
+## Payment Methods & Intents
+
+**Available methods (production):** `tempo` (TIP-20 stablecoins, sub-second settlement), `stripe`
+**In-spec:** `card`, `lightning`
+
+**Intent types:**
+- `charge` — one-time immediate settlement
+- `session` — streaming payment over a payment channel
+
+Key0 currently implements x402 with Base/USDC — this maps to the `tempo` method concept.
+
+### Custom Methods
+
+Anyone can define a new method by specifying:
+1. Method identifier (lowercase ASCII)
+2. `request` schema (what the server asks for)
+3. `payload` schema (what the client provides as proof)
+4. Verification procedure
+5. Settlement procedure
+
+A Key0-compatible custom MPP method could wrap the existing ERC-20 Transfer + viem verification
+in `src/adapter/`.
+
+---
+
+## Security Invariants (aligned with Key0 SPEC.md)
+
+MPP's spec mandates the same invariants Key0 already enforces:
+
+| Invariant | MPP Requirement | Key0 Implementation |
+|---|---|---|
+| Single-use proofs | Credentials valid for exactly one request; replay must be rejected | `ISeenTxStore.markUsed()` atomic SET NX |
+| No side effects before payment | Servers must not perform side effects for unpaid requests | `preSettlementCheck()` guard |
+| Amount verification | Clients must verify amount, recipient, currency, validity window | Client-side before signing |
+| TLS required | TLS 1.2+ required for all Payment flows | Standard HTTPS deployment |
+| No credential logging | Payment credentials must not appear in logs/errors/analytics | Key0 does not log raw proofs |
+| Challenge binding | `id` must be cryptographically bound to parameters | Key0 uses HMAC-bound challenge IDs |
+| Idempotency | Non-idempotent methods should accept `Idempotency-Key` | x402 challenges are idempotent by design |
+
+---
+
+## Key Differences vs Key0's Current x402
+
+| Dimension | Key0 x402 Today | MPP |
+|---|---|---|
+| Header scheme | Custom `X-402-*` headers + `PaymentRequirements` JSON body | Standard `WWW-Authenticate: Payment` / `Authorization: Payment` |
+| Challenge encoding | JSON body in `402` response | `auth-params` in `WWW-Authenticate` header |
+| Credential encoding | Custom `PaymentPayload` object | `base64url` JSON in `Authorization: Payment` header |
+| Receipt | `AccessGrant` JWT | `Payment-Receipt` base64url-JSON header (optional) |
+| Payment method | ERC-20 USDC on Base | Any rail via pluggable `method` param |
+| Error codes | HTTP-level + problem strings | RFC 9457 Problem Details with typed URIs |
+| MCP binding | Custom `isError`+`structuredContent` | Standard `-32042` + `_meta` |
+| Multi-method | Single method per endpoint | Multiple `WWW-Authenticate` headers, client picks |
+
+---
+
+## Migration / Compatibility Surface in Key0
+
+The following components would need updates to speak native MPP:
+
+### `src/core/challenge-engine.ts`
+- `requestHttpAccess` / `processHttpPayment`: emit `WWW-Authenticate: Payment …` instead of custom response body.
+- Error responses: wrap in RFC 9457 Problem Details with typed `https://paymentauth.org/problems/…` URIs.
+
+### `src/integrations/` (Express, Hono, Fastify, MCP)
+- HTTP middleware: parse `Authorization: Payment <base64url>` instead of current `PaymentPayload` format.
+- MCP integration: replace custom `structuredContent`/`isError` with JSON-RPC error `-32042` and `_meta.org.paymentauth/*`.
+
+### `src/adapter/` (`X402Adapter`)
+- Verification interface stays the same; only the credential envelope changes (MPP `payload` object instead of current `PaymentPayload`).
+
+### `src/integrations/settlement.ts`
+- `buildHttpPaymentRequirements`: emit MPP-format `WWW-Authenticate` header string.
+- `decodePaymentSignature`: decode from MPP credential JSON instead of current format.
+
+### New: Receipt header
+- Key0 currently issues a signed JWT (`AccessGrant`) as the grant mechanism.
+- Under MPP, the `200` response would carry a `Payment-Receipt` header, and the application credential (JWT/API key) would be issued separately or embedded in the receipt's `reference` field.
+
+---
+
+## Opportunity: Key0 as MPP Server
+
+Key0's architecture is a near-perfect fit for an MPP server implementation:
+
+- The state machine (`PENDING → PAID → DELIVERED`) maps to the MPP request/challenge/credential/receipt lifecycle.
+- `IChallengeStore` can store MPP-format challenges directly.
+- `ISeenTxStore` satisfies MPP's single-use credential requirement.
+- The existing `X402Adapter` verifies on-chain transfers — this becomes the `verify` procedure for a custom `key0-usdc` MPP method.
+- `IAuditStore` provides the audit trail MPP receipts are designed for.
+
+A future `createMppKey0()` factory could expose a fully MPP-compliant server while reusing
+all existing storage, adapter, and token-issuance infrastructure.
+
+---
+
+## References
+
+- [MPP Overview](https://mpp.dev/overview)
+- [MPP Protocol Concepts](https://mpp.dev/protocol)
+- [MPP HTTP Transport](https://mpp.dev/protocol/transports/http)
+- [MPP MCP Transport](https://mpp.dev/protocol/transports/mcp)
+- [MPP Custom Methods](https://mpp.dev/payment-methods/custom)
+- [IETF Specification](https://paymentauth.org/)
+- [mppx TypeScript SDK](https://mpp.dev/sdk)

--- a/docs/superpowers/plans/2026-03-19-agent-onboarding.md
+++ b/docs/superpowers/plans/2026-03-19-agent-onboarding.md
@@ -1,0 +1,1566 @@
+# Agent Onboarding Experience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/skill.md`, `/llms.txt`, `/install.sh`, and `/cli/*` endpoints to all Key0 framework routers, auto-building CLI binaries at startup on Bun servers with graceful fallback on Node.js.
+
+**Architecture:** A new `AgentCliServer` class holds build state and is instantiated during router creation with injectable deps for testability. Pure content generators in `agent-discovery.ts` produce all text content and are shared between server endpoints and `buildCli()` static artifacts. Each framework router (Express, Hono, Fastify) mounts the four new routes using the same `AgentCliServer` instance. Route tests start a real test server and use `fetch`.
+
+**Tech Stack:** Bun (runtime detection + compile), TypeScript, Express/Hono/Fastify, `bun:test`
+
+---
+
+## Working directory
+
+All implementation happens in the `feat/enable-cli` worktree:
+```
+/Users/srijan/Documents/riklr/key0/.worktrees/feat-enable-cli
+```
+
+---
+
+## File structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| **Create** | `src/integrations/agent-discovery.ts` | Pure content generators: `slugifyBinaryName`, `generateSkillMdContent`, `generateLlmsTxt`, `generateInstallSh`, `generateClaudeSkillMd`, `generateAgentExperienceMd` |
+| **Create** | `src/integrations/__tests__/agent-discovery.test.ts` | Unit tests for all generators |
+| **Create** | `src/integrations/agent-cli-server.ts` | `AgentCliServer` class: Bun detection, background build, state tracking |
+| **Create** | `src/integrations/__tests__/agent-cli-server.test.ts` | State machine unit tests |
+| **Modify** | `src/types/config.ts` | Add `cliOutputDir?: string` to `SellerConfig` |
+| **Modify** | `src/integrations/cli.ts` | Replace `generateSkillMd` with shared generators; expand `BuildCliResult` |
+| **Modify** | `src/integrations/__tests__/cli-build.test.ts` | Update for new `BuildCliResult` fields |
+| **Modify** | `src/integrations/express.ts` | Import `AgentCliServer`; mount 4 new routes |
+| **Create** | `src/integrations/__tests__/express-agent-routes.test.ts` | HTTP-level route tests |
+| **Modify** | `src/integrations/hono.ts` | Mount 4 new routes |
+| **Modify** | `src/integrations/fastify.ts` | Mount 4 new routes |
+| **Create** | `docs/mintlify/guides/agent-experience.mdx` | New seller guide |
+| **Modify** | `docs/mintlify/guides/agent-cli.mdx` | Update primary path |
+| **Modify** | `docs/mintlify/guides/claude-code-integration.mdx` | Add Step 0 |
+
+---
+
+## Task 1: Rebase feat/enable-cli from main
+
+- [ ] **Step 1: Rebase**
+
+```bash
+cd /Users/srijan/Documents/riklr/key0/.worktrees/feat-enable-cli
+git fetch origin main
+git rebase origin/main
+```
+
+Expected: clean rebase. Resolve any conflicts.
+
+- [ ] **Step 2: Verify tests still pass**
+
+```bash
+bun test
+```
+
+Expected: all existing tests pass.
+
+---
+
+## Task 2: `slugifyBinaryName()` — TDD
+
+**Files:**
+- Create: `src/integrations/agent-discovery.ts`
+- Create: `src/integrations/__tests__/agent-discovery.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/integrations/__tests__/agent-discovery.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { slugifyBinaryName } from "../agent-discovery.js";
+
+describe("slugifyBinaryName", () => {
+	test("lowercases and replaces spaces with hyphens", () => {
+		expect(slugifyBinaryName("Acme API")).toBe("acme-api");
+	});
+
+	test("handles special characters in parens", () => {
+		expect(slugifyBinaryName("My API (v2)")).toBe("my-api-v2");
+	});
+
+	test("transliterates accented characters", () => {
+		expect(slugifyBinaryName("Café Data")).toBe("cafe-data");
+	});
+
+	test("collapses consecutive hyphens", () => {
+		expect(slugifyBinaryName("  !! bad name !! ")).toBe("bad-name");
+	});
+
+	test("strips leading and trailing hyphens", () => {
+		expect(slugifyBinaryName("-foo-")).toBe("foo");
+	});
+
+	test("falls back to key0-service when result is empty", () => {
+		expect(slugifyBinaryName("!!!")).toBe("key0-service");
+		expect(slugifyBinaryName("")).toBe("key0-service");
+	});
+
+	test("leaves already-valid binary name unchanged", () => {
+		expect(slugifyBinaryName("my-service")).toBe("my-service");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+bun test src/integrations/__tests__/agent-discovery.test.ts
+```
+
+Expected: `error: Cannot find module '../agent-discovery.js'`
+
+- [ ] **Step 3: Create `agent-discovery.ts` with `slugifyBinaryName`**
+
+Create `src/integrations/agent-discovery.ts`:
+
+```typescript
+/**
+ * Agent discovery content generators.
+ * All functions are pure — no side effects, no file I/O.
+ */
+
+/**
+ * Derive a valid shell binary name from an agent name.
+ * Steps: NFC normalize → strip diacritics → lowercase → replace non-[a-z0-9] with hyphens
+ *        → collapse consecutive hyphens → strip leading/trailing hyphens → fallback "key0-service"
+ */
+export function slugifyBinaryName(name: string): string {
+	const ascii = name
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "") // strip diacritics after NFC decomposition
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "");
+
+	return ascii.length > 0 ? ascii : "key0-service";
+}
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```bash
+bun test src/integrations/__tests__/agent-discovery.test.ts
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/agent-discovery.ts src/integrations/__tests__/agent-discovery.test.ts
+git commit -m "feat(agent-discovery): add slugifyBinaryName with TDD"
+```
+
+---
+
+## Task 3: Content generators — TDD
+
+**Files:**
+- Modify: `src/integrations/agent-discovery.ts`
+- Modify: `src/integrations/__tests__/agent-discovery.test.ts`
+
+- [ ] **Step 1: Add tests for all generators**
+
+Append to `src/integrations/__tests__/agent-discovery.test.ts`:
+
+```typescript
+import {
+	generateAgentExperienceMd,
+	generateClaudeSkillMd,
+	generateInstallSh,
+	generateLlmsTxt,
+	generateSkillMdContent,
+} from "../agent-discovery.js";
+
+const baseConfig: import("../agent-discovery.js").AgentDiscoveryConfig = {
+	agentName: "Acme API",
+	agentUrl: "https://api.acme.com",
+	agentDescription: "Payment-gated data API",
+	providerName: "Acme Corp",
+	providerUrl: "https://acme.com",
+	plans: [
+		{ planId: "basic", unitAmount: "$0.10", description: "Basic access" },
+		{ planId: "pro", unitAmount: "$1.00" },
+	],
+	mcp: true,
+};
+
+describe("generateSkillMdContent — CLI available", () => {
+	const md = generateSkillMdContent(baseConfig, true);
+
+	test("contains binary name derived from agentName", () => {
+		expect(md).toContain("acme-api");
+	});
+
+	test("contains install curl command pointing to /install.sh", () => {
+		expect(md).toContain("curl -fsSL https://api.acme.com/install.sh | sh");
+	});
+
+	test("contains all three usage commands", () => {
+		expect(md).toContain("acme-api discover");
+		expect(md).toContain("acme-api request --plan");
+		expect(md).toContain("--payment-signature");
+	});
+
+	test("contains plans table with both plans", () => {
+		expect(md).toContain("basic");
+		expect(md).toContain("$0.10");
+		expect(md).toContain("pro");
+	});
+});
+
+describe("generateSkillMdContent — CLI not available", () => {
+	const md = generateSkillMdContent(baseConfig, false);
+
+	test("does NOT contain install.sh", () => {
+		expect(md).not.toContain("install.sh");
+	});
+
+	test("contains MCP fallback with /mcp URL", () => {
+		expect(md).toContain("mcpServers");
+		expect(md).toContain("https://api.acme.com/mcp");
+	});
+
+	test("contains HTTP endpoint fallback", () => {
+		expect(md).toContain("/discovery");
+		expect(md).toContain("/x402/access");
+	});
+});
+
+describe("generateLlmsTxt", () => {
+	test("includes CLI install line when bunReady=true", () => {
+		const txt = generateLlmsTxt(baseConfig, true);
+		expect(txt).toContain("curl -fsSL https://api.acme.com/install.sh | sh");
+	});
+
+	test("omits CLI install line when bunReady=false", () => {
+		const txt = generateLlmsTxt(baseConfig, false);
+		expect(txt).not.toContain("install.sh");
+	});
+
+	test("includes MCP endpoint when mcp=true", () => {
+		const txt = generateLlmsTxt(baseConfig, false);
+		expect(txt).toContain("https://api.acme.com/mcp");
+	});
+
+	test("omits MCP endpoint when mcp=false", () => {
+		const txt = generateLlmsTxt({ ...baseConfig, mcp: false }, false);
+		expect(txt).not.toContain("/mcp");
+	});
+
+	test("includes all plans", () => {
+		const txt = generateLlmsTxt(baseConfig, false);
+		expect(txt).toContain("basic");
+		expect(txt).toContain("pro");
+	});
+
+	test("includes 5-step payment flow", () => {
+		const txt = generateLlmsTxt(baseConfig, false);
+		expect(txt).toContain("/discovery");
+		expect(txt).toContain("/x402/access");
+		expect(txt).toContain("payment-signature");
+	});
+});
+
+describe("generateInstallSh", () => {
+	const sh = generateInstallSh("acme-api", "https://api.acme.com");
+
+	test("contains all three platform cases", () => {
+		expect(sh).toContain("darwin_arm64");
+		expect(sh).toContain("darwin_x86_64");
+		expect(sh).toContain("linux_x86_64");
+	});
+
+	test("uses /cli/ base path", () => {
+		expect(sh).toContain("https://api.acme.com/cli");
+	});
+
+	test("binary names include correct platform suffixes", () => {
+		expect(sh).toContain("acme-api-darwin-arm64");
+		expect(sh).toContain("acme-api-darwin-x64");
+		expect(sh).toContain("acme-api-linux-x64");
+	});
+
+	test("runs --install after download", () => {
+		expect(sh).toContain("--install");
+	});
+
+	test("strips trailing slash from URL", () => {
+		const sh2 = generateInstallSh("acme-api", "https://api.acme.com/");
+		expect(sh2).not.toContain("//cli");
+	});
+});
+
+describe("generateClaudeSkillMd", () => {
+	const md = generateClaudeSkillMd("acme-api", baseConfig);
+
+	test("has valid YAML frontmatter with name and description", () => {
+		expect(md).toContain("---\nname: acme-api");
+		expect(md).toContain("description:");
+	});
+
+	test("contains the 5-step flow including wallet tool", () => {
+		expect(md).toContain("acme-api discover");
+		expect(md).toContain("make_http_request_with_x402");
+		expect(md).toContain("--payment-signature");
+		expect(md).toContain("resourceUrl");
+	});
+});
+
+describe("generateAgentExperienceMd", () => {
+	const md = generateAgentExperienceMd("acme-api", baseConfig);
+
+	test("contains badge linking to install.sh", () => {
+		expect(md).toContain("install.sh");
+		expect(md).toContain("img.shields.io");
+	});
+
+	test("example uses first plan planId", () => {
+		expect(md).toContain("--plan basic");
+	});
+
+	test("links to skill.md", () => {
+		expect(md).toContain("https://api.acme.com/skill.md");
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+bun test src/integrations/__tests__/agent-discovery.test.ts
+```
+
+Expected: import errors for missing exports.
+
+- [ ] **Step 3: Implement all generators**
+
+Append to `src/integrations/agent-discovery.ts`:
+
+```typescript
+export type AgentDiscoveryConfig = {
+	agentName: string;
+	agentUrl: string;
+	agentDescription: string;
+	providerName?: string;
+	providerUrl?: string;
+	plans: ReadonlyArray<{ planId: string; unitAmount: string; description?: string }>;
+	mcp?: boolean;
+	version?: string;
+};
+
+/**
+ * Generate /skill.md content.
+ * bunReady=true → CLI-first (install + usage + plans).
+ * bunReady=false → MCP/HTTP fallback.
+ */
+export function generateSkillMdContent(config: AgentDiscoveryConfig, bunReady: boolean): string {
+	const cleanUrl = config.agentUrl.replace(/\/$/, "");
+	const binaryName = slugifyBinaryName(config.agentName);
+
+	if (!bunReady) {
+		const mcpSection = config.mcp
+			? `## Access via MCP\n\n\`\`\`json\n{ "mcpServers": { "${binaryName}": { "type": "http", "url": "${cleanUrl}/mcp" } } }\n\`\`\`\n\nUse \`discover_plans\` and \`request_access\` tools.\n\n`
+			: "";
+		return `# ${config.agentName}\n\n${mcpSection}## Access via HTTP\n\nDiscovery: GET ${cleanUrl}/discovery\nPayment:   POST ${cleanUrl}/x402/access\n`;
+	}
+
+	const plansTable = [
+		"| Plan | Price | Description |",
+		"|------|-------|-------------|",
+		...config.plans.map((p) => `| ${p.planId} | ${p.unitAmount} | ${p.description ?? ""} |`),
+	].join("\n");
+
+	return `# ${config.agentName}
+
+Install \`${binaryName}\` to access ${cleanUrl} autonomously — no API keys, no sign-up.
+
+## Install
+
+\`\`\`bash
+curl -fsSL ${cleanUrl}/install.sh | sh
+\`\`\`
+
+## Usage
+
+\`\`\`bash
+${binaryName} discover                                            # list plans and pricing
+${binaryName} request --plan <planId>                            # get payment challenge
+${binaryName} request --plan <planId> --payment-signature <sig>  # submit payment proof
+\`\`\`
+
+Exit code \`42\` = payment required. Exit code \`0\` = access granted. All output is JSON.
+
+## Plans
+
+${plansTable}
+
+## Payment
+
+Use any x402-compatible wallet tool to produce \`--payment-signature\`.
+With coinbase-payment-mcp: use \`make_http_request_with_x402\`.
+`;
+}
+
+/** Generate /llms.txt content (llms.txt convention). */
+export function generateLlmsTxt(config: AgentDiscoveryConfig, bunReady: boolean): string {
+	const cleanUrl = config.agentUrl.replace(/\/$/, "");
+	const plans = config.plans
+		.map((p) => `- ${p.planId}: ${p.unitAmount}${p.description ? ` — ${p.description}` : ""}`)
+		.join("\n");
+
+	const cliLine = bunReady ? `- CLI install: curl -fsSL ${cleanUrl}/install.sh | sh\n` : "";
+	const mcpLine = config.mcp ? `- MCP: ${cleanUrl}/mcp\n` : "";
+
+	return `# ${config.agentName}
+
+> ${config.agentDescription}
+
+${config.agentName} is a payment-gated API. Agents pay with USDC on Base; no sign-up required.
+
+## Endpoints
+
+- Discovery: GET ${cleanUrl}/discovery
+- Payment: POST ${cleanUrl}/x402/access
+${mcpLine}- A2A card: ${cleanUrl}/.well-known/agent.json
+- Agent instructions: ${cleanUrl}/skill.md
+${cliLine}
+## Plans
+
+${plans}
+
+## Payment flow
+
+1. GET /discovery → see plans, wallet address, chainId
+2. POST /x402/access { planId } → 402 challenge (amount, destination, chainId)
+3. Pay USDC on Base, obtain payment signature from wallet tool
+4. POST /x402/access { planId } + payment-signature header → AccessGrant (JWT, resourceUrl)
+5. Call protected endpoint with Bearer token
+${config.providerUrl ? `\n## Optional links\n\n- Docs: https://key0.ai/docs\n- Provider: ${config.providerUrl}\n` : ""}`;
+}
+
+/** Generate /install.sh shell script content. */
+export function generateInstallSh(binaryName: string, agentUrl: string): string {
+	const cleanUrl = agentUrl.replace(/\/$/, "");
+	return `#!/bin/sh
+set -e
+BASE="${cleanUrl}/cli"
+ARCH=$(uname -m)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "\${OS}_\${ARCH}" in
+  darwin_arm64)   BIN="${binaryName}-darwin-arm64" ;;
+  darwin_x86_64)  BIN="${binaryName}-darwin-x64"   ;;
+  linux_x86_64)   BIN="${binaryName}-linux-x64"    ;;
+  *) echo "Unsupported platform: \${OS}_\${ARCH}"; exit 1 ;;
+esac
+curl -fsSL "$BASE/$BIN" -o ${binaryName}
+chmod +x ./${binaryName}
+./${binaryName} --install
+echo "Installed ${binaryName}. Run: ${binaryName} discover"
+`;
+}
+
+/** Generate a Claude Code superpowers-format skill file. */
+export function generateClaudeSkillMd(binaryName: string, config: AgentDiscoveryConfig): string {
+	const cleanUrl = config.agentUrl.replace(/\/$/, "");
+	return `---
+name: ${binaryName}
+description: Use when interacting with ${config.agentName} — discover plans, pay with USDC, get access tokens. Trigger on any request to use ${config.agentName} or access ${cleanUrl}.
+---
+
+You have access to the \`${binaryName}\` CLI. Use it to interact with ${config.agentName} at ${cleanUrl}.
+
+## Flow
+
+1. \`${binaryName} discover\` → see available plans and pricing
+2. \`${binaryName} request --plan <planId>\` → if exit code is \`42\`, payment required
+3. Use \`make_http_request_with_x402\` (coinbase-payment-mcp) with the challenge JSON to obtain a payment signature
+4. \`${binaryName} request --plan <planId> --payment-signature <sig>\` → exit \`0\`, returns \`{ token, resourceUrl }\`
+5. Call \`resourceUrl\` with \`Authorization: Bearer <token>\`
+
+All output is JSON. Parse directly — do not screen-scrape.
+If coinbase-payment-mcp is unavailable, check for another x402-compatible wallet tool.
+`;
+}
+
+/** Generate the agent-experience.md README copy-paste block. */
+export function generateAgentExperienceMd(binaryName: string, config: AgentDiscoveryConfig): string {
+	const cleanUrl = config.agentUrl.replace(/\/$/, "");
+	const firstPlan = config.plans[0]?.planId ?? "basic";
+	return `## For AI Agents
+
+This API is accessible to AI agents with USDC on Base — no sign-up required.
+
+[![Agent CLI](https://img.shields.io/badge/agent--cli-install-blue)](${cleanUrl}/install.sh)
+
+\`\`\`bash
+curl -fsSL ${cleanUrl}/install.sh | sh
+${binaryName} discover
+${binaryName} request --plan ${firstPlan}
+\`\`\`
+
+Agent instructions: ${cleanUrl}/skill.md
+`;
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+bun test src/integrations/__tests__/agent-discovery.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/agent-discovery.ts src/integrations/__tests__/agent-discovery.test.ts
+git commit -m "feat(agent-discovery): add content generators for skill.md, llms.txt, install.sh, claude skill"
+```
+
+---
+
+## Task 4: `AgentCliServer` class — TDD
+
+**Files:**
+- Create: `src/integrations/agent-cli-server.ts`
+- Create: `src/integrations/__tests__/agent-cli-server.test.ts`
+
+**Important:** `AgentCliServer` accepts `AgentDiscoveryConfig & { cliOutputDir?: string }` — it does NOT import from `SellerConfig`. This avoids ordering dependency on the `SellerConfig` type change in Task 5.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/integrations/__tests__/agent-cli-server.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { AgentCliServer } from "../agent-cli-server.js";
+
+const baseConfig: import("../agent-cli-server.js").AgentCliConfig = {
+	agentName: "Test Service",
+	agentUrl: "https://test.example.com",
+	agentDescription: "Test API",
+	providerName: "Test",
+	providerUrl: "https://test.example.com",
+	plans: [{ planId: "basic", unitAmount: "$0.10" }],
+	mcp: false,
+};
+
+describe("AgentCliServer — not-available (isBunRuntime=false)", () => {
+	test("getState() returns not-available", () => {
+		const server = new AgentCliServer(baseConfig, { isBunRuntime: false });
+		expect(server.getState()).toBe("not-available");
+	});
+
+	test("getBinaryName() returns slugified agentName", () => {
+		const server = new AgentCliServer(baseConfig, { isBunRuntime: false });
+		expect(server.getBinaryName()).toBe("test-service");
+	});
+
+	test("isCliReady() returns false", () => {
+		const server = new AgentCliServer(baseConfig, { isBunRuntime: false });
+		expect(server.isCliReady()).toBe(false);
+	});
+
+	test("getSkillMd() returns MCP/HTTP fallback (no install.sh)", () => {
+		const server = new AgentCliServer(baseConfig, { isBunRuntime: false });
+		expect(server.getSkillMd()).not.toContain("install.sh");
+		expect(server.getSkillMd()).toContain("/discovery");
+	});
+
+	test("getLlmsTxt() omits CLI line", () => {
+		const server = new AgentCliServer(baseConfig, { isBunRuntime: false });
+		expect(server.getLlmsTxt()).not.toContain("install.sh");
+	});
+});
+
+describe("AgentCliServer — building (buildFn never resolves)", () => {
+	test("getState() returns building immediately after construction", () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => new Promise(() => {}), // never resolves
+		});
+		expect(server.getState()).toBe("building");
+	});
+
+	test("isCliReady() returns false while building", () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => new Promise(() => {}),
+		});
+		expect(server.isCliReady()).toBe(false);
+	});
+
+	test("getSkillMd() returns fallback content while building", () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => new Promise(() => {}),
+		});
+		expect(server.getSkillMd()).not.toContain("install.sh");
+	});
+});
+
+describe("AgentCliServer — ready (buildFn resolves immediately)", () => {
+	test("getState() returns ready after build completes", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.resolve(),
+		});
+		await new Promise((r) => setTimeout(r, 0)); // flush microtask queue
+		expect(server.getState()).toBe("ready");
+	});
+
+	test("isCliReady() returns true when ready", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.resolve(),
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(server.isCliReady()).toBe(true);
+	});
+
+	test("getSkillMd() returns CLI-first content when ready", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.resolve(),
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(server.getSkillMd()).toContain("install.sh");
+		expect(server.getSkillMd()).toContain("test-service discover");
+	});
+
+	test("getInstallSh() returns shell script with correct binary name", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.resolve(),
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		const sh = server.getInstallSh();
+		expect(sh).toContain("test-service-linux-x64");
+		expect(sh).toContain("test-service-darwin-arm64");
+	});
+});
+
+describe("AgentCliServer — failed (buildFn rejects)", () => {
+	test("getState() returns failed when build throws", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.reject(new Error("build failed")),
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(server.getState()).toBe("failed");
+	});
+
+	test("isCliReady() returns false when failed", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.reject(new Error("build failed")),
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(server.isCliReady()).toBe(false);
+	});
+
+	test("getSkillMd() returns fallback content when failed", async () => {
+		const server = new AgentCliServer(baseConfig, {
+			isBunRuntime: true,
+			buildFn: () => Promise.reject(new Error("build failed")),
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(server.getSkillMd()).not.toContain("install.sh");
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+bun test src/integrations/__tests__/agent-cli-server.test.ts
+```
+
+Expected: `Cannot find module '../agent-cli-server.js'`
+
+- [ ] **Step 3: Implement `AgentCliServer`**
+
+Create `src/integrations/agent-cli-server.ts`:
+
+```typescript
+import {
+	type AgentDiscoveryConfig,
+	generateInstallSh,
+	generateLlmsTxt,
+	generateSkillMdContent,
+	slugifyBinaryName,
+} from "./agent-discovery.js";
+
+export type CliState = "not-available" | "building" | "ready" | "failed";
+
+export interface AgentCliServerOptions {
+	/**
+	 * Override Bun runtime detection for testing.
+	 * Default: typeof Bun !== "undefined"
+	 */
+	isBunRuntime?: boolean;
+	/**
+	 * Override build function for testing.
+	 * Default: calls buildCli() with the seller config.
+	 */
+	buildFn?: () => Promise<void>;
+}
+
+export type AgentCliConfig = AgentDiscoveryConfig & {
+	/** Directory to cache built CLI binaries. Default: "./dist/cli" */
+	cliOutputDir?: string;
+};
+
+/**
+ * Manages CLI binary build state for a Key0 router.
+ * Instantiated once at router creation; the build runs in the background.
+ * The constructor is synchronous — app.listen() is never delayed.
+ */
+export class AgentCliServer {
+	private state: CliState;
+	private readonly binaryName: string;
+	private readonly config: AgentCliConfig;
+	private readonly outputDir: string;
+
+	constructor(config: AgentCliConfig, opts: AgentCliServerOptions = {}) {
+		this.config = config;
+		this.binaryName = slugifyBinaryName(config.agentName);
+		this.outputDir = config.cliOutputDir ?? "./dist/cli";
+
+		const isBun = opts.isBunRuntime ?? typeof Bun !== "undefined";
+
+		if (!isBun) {
+			this.state = "not-available";
+			return;
+		}
+
+		this.state = "building";
+		const buildFn = opts.buildFn ?? (() => this.runBuild());
+		buildFn()
+			.then(() => {
+				this.state = "ready";
+			})
+			.catch((err: unknown) => {
+				this.state = "failed";
+				console.error("[key0] CLI auto-build failed:", err);
+			});
+	}
+
+	private async runBuild(): Promise<void> {
+		// Lazy import avoids pulling Bun-specific compilation code into Node bundles
+		const { buildCli } = await import("./cli.js");
+		await buildCli({
+			name: this.binaryName,
+			url: this.config.agentUrl,
+			version: this.config.version ?? "0.0.0",
+			targets: ["bun-linux-x64", "bun-darwin-arm64", "bun-darwin-x64"],
+			outputDir: this.outputDir,
+			discoverConfig: this.config,
+		});
+	}
+
+	getState(): CliState { return this.state; }
+	getBinaryName(): string { return this.binaryName; }
+	getOutputDir(): string { return this.outputDir; }
+	isCliReady(): boolean { return this.state === "ready"; }
+
+	getSkillMd(): string {
+		return generateSkillMdContent(this.config, this.isCliReady());
+	}
+
+	getLlmsTxt(): string {
+		return generateLlmsTxt(this.config, this.isCliReady());
+	}
+
+	getInstallSh(): string {
+		return generateInstallSh(this.binaryName, this.config.agentUrl);
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+bun test src/integrations/__tests__/agent-cli-server.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/agent-cli-server.ts src/integrations/__tests__/agent-cli-server.test.ts
+git commit -m "feat(agent-cli-server): add AgentCliServer with injectable deps and build state machine"
+```
+
+---
+
+## Task 5: Update `SellerConfig` and `buildCli()`
+
+**Files:**
+- Modify: `src/types/config.ts`
+- Modify: `src/integrations/cli.ts`
+- Modify: `src/integrations/__tests__/cli-build.test.ts`
+
+- [ ] **Step 1: Add `cliOutputDir` to `SellerConfig`**
+
+In `src/types/config.ts`, add after the `redis` field in `SellerConfig`:
+
+```typescript
+/**
+ * Directory to cache auto-built CLI binaries.
+ * In Docker deployments, use an absolute path (e.g. "/app/dist/cli")
+ * since process.cwd() may not be the project root.
+ * Default: "./dist/cli"
+ */
+readonly cliOutputDir?: string;
+```
+
+- [ ] **Step 2: Run typecheck to confirm no errors**
+
+```bash
+bun run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Write failing test for new `BuildCliResult` fields**
+
+In `src/integrations/__tests__/cli-build.test.ts`, add this test to the `buildCli` describe block (before the existing tests):
+
+```typescript
+import { readFileSync } from "node:fs";
+
+test("generates claudeSkillMd and agentExperienceMd artifacts", async () => {
+	const result = await buildCli({
+		name: "testcli",
+		url: "https://api.example.com",
+		targets: [],
+		outputDir,
+		discoverConfig: {
+			agentName: "Test CLI",
+			agentUrl: "https://api.example.com",
+			agentDescription: "Test service",
+			plans: [{ planId: "basic", unitAmount: "$0.10" }],
+		},
+	});
+
+	expect(existsSync(result.claudeSkillMd)).toBe(true);
+	expect(existsSync(result.agentExperienceMd)).toBe(true);
+
+	const claudeSkill = readFileSync(result.claudeSkillMd, "utf-8");
+	expect(claudeSkill).toContain("---\nname: testcli");
+
+	const agentExp = readFileSync(result.agentExperienceMd, "utf-8");
+	expect(agentExp).toContain("--plan basic");
+}, 120_000);
+```
+
+- [ ] **Step 4: Run the new test to confirm it fails**
+
+```bash
+bun test src/integrations/__tests__/cli-build.test.ts --test-name-pattern "generates claudeSkillMd"
+```
+
+Expected: type error or `result.claudeSkillMd is undefined`.
+
+- [ ] **Step 5: Update `BuildCliOptions` and `BuildCliResult` in `cli.ts`**
+
+In `src/integrations/cli.ts`:
+
+1. Add import at the top:
+```typescript
+import {
+	generateAgentExperienceMd,
+	generateClaudeSkillMd,
+	type AgentDiscoveryConfig,
+	generateSkillMdContent,
+} from "./agent-discovery.js";
+```
+
+2. Add `discoverConfig` to `BuildCliOptions`:
+```typescript
+export interface BuildCliOptions {
+	name: string;
+	url: string;
+	version?: string;
+	targets?: string[];
+	outputDir?: string;
+	/**
+	 * Full agent config for richer skill.md content (plans, description, etc).
+	 * When omitted, skill.md uses name/url only.
+	 */
+	discoverConfig?: AgentDiscoveryConfig;
+}
+```
+
+3. Update `BuildCliResult`:
+```typescript
+export interface BuildCliResult {
+	binaries: Array<{ path: string; target: string; size: number }>;
+	skillMd: string;           // path to dist/cli/skill.md
+	claudeSkillMd: string;     // path to dist/cli/{name}.claude-skill.md
+	agentExperienceMd: string; // path to dist/cli/agent-experience.md
+}
+```
+
+4. In `buildCli()`, replace the `generateSkillMd` call block at the end with:
+```typescript
+const dc: AgentDiscoveryConfig = opts.discoverConfig ?? {
+	agentName: opts.name,
+	agentUrl: opts.url,
+	agentDescription: "",
+	plans: [],
+};
+
+const skillMdPath = join(outputDir, "skill.md");
+writeFileSync(skillMdPath, generateSkillMdContent(dc, true), "utf-8");
+
+const claudeSkillPath = join(outputDir, `${opts.name}.claude-skill.md`);
+writeFileSync(claudeSkillPath, generateClaudeSkillMd(opts.name, dc), "utf-8");
+
+const agentExpPath = join(outputDir, "agent-experience.md");
+writeFileSync(agentExpPath, generateAgentExperienceMd(opts.name, dc), "utf-8");
+
+return { binaries, skillMd: skillMdPath, claudeSkillMd: claudeSkillPath, agentExperienceMd: agentExpPath };
+```
+
+5. Remove the old `generateSkillMd` function entirely (it is not exported from `src/index.ts` — verified).
+
+- [ ] **Step 6: Run the new test to confirm it passes**
+
+```bash
+bun test src/integrations/__tests__/cli-build.test.ts
+```
+
+Expected: all tests pass (may take up to 2 minutes for compilation).
+
+- [ ] **Step 7: Run full test suite to confirm no regressions**
+
+```bash
+bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/types/config.ts src/integrations/cli.ts src/integrations/__tests__/cli-build.test.ts
+git commit -m "feat(cli): add cliOutputDir to SellerConfig; expand BuildCliResult with new artifacts"
+```
+
+---
+
+## Task 6: Mount routes in Express + route tests
+
+**Files:**
+- Modify: `src/integrations/express.ts`
+- Create: `src/integrations/__tests__/express-agent-routes.test.ts`
+
+- [ ] **Step 1: Write failing HTTP-level route tests**
+
+Create `src/integrations/__tests__/express-agent-routes.test.ts`:
+
+```typescript
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import express from "express";
+import type { Server } from "node:http";
+import { AgentCliServer } from "../agent-cli-server.js";
+
+// Minimal config — no real payment adapter needed for these tests
+const testConfig: import("../agent-cli-server.js").AgentCliConfig = {
+	agentName: "Test Service",
+	agentUrl: "http://localhost", // overridden per-test via spread
+	agentDescription: "Test API",
+	plans: [{ planId: "basic", unitAmount: "$0.10" }],
+	mcp: false,
+};
+
+function makeRouteHandlers(agentCli: AgentCliServer) {
+	const router = express.Router();
+	// Import route logic inline for testing — actual routes live in express.ts
+	// This test will FAIL until express.ts mounts the routes
+	return router;
+}
+
+// Start a real Express server with key0Router (non-Bun mode via injectable)
+async function startTestServer(agentCliOpts: import("../agent-cli-server.js").AgentCliServerOptions): Promise<{ server: Server; baseUrl: string; agentCli: AgentCliServer }> {
+	const app = express();
+	const agentCli = new AgentCliServer({ ...testConfig, agentUrl: "https://api.test.com" }, agentCliOpts);
+
+	// Mount ONLY the four new routes for testing (same logic as express.ts will implement)
+	app.get("/skill.md", (_req, res) => {
+		res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+		res.send(agentCli.getSkillMd());
+	});
+
+	app.get("/llms.txt", (_req, res) => {
+		res.setHeader("Content-Type", "text/plain; charset=utf-8");
+		res.send(agentCli.getLlmsTxt());
+	});
+
+	app.get("/install.sh", (_req, res) => {
+		const state = agentCli.getState();
+		if (state === "not-available" || state === "failed") {
+			return res.status(501).json({ error: "CLI not available" });
+		}
+		if (!agentCli.isCliReady()) {
+			res.setHeader("Retry-After", "30");
+			return res.status(503).json({ error: "CLI is building", retryAfter: 30 });
+		}
+		res.setHeader("Content-Type", "text/x-shellscript");
+		res.send(agentCli.getInstallSh());
+	});
+
+	return new Promise((resolve) => {
+		const server = app.listen(0, () => {
+			const addr = server.address() as { port: number };
+			resolve({ server, baseUrl: `http://localhost:${addr.port}`, agentCli });
+		});
+	});
+}
+
+describe("Express agent routes — not-available (non-Bun)", () => {
+	let server: Server;
+	let baseUrl: string;
+
+	beforeAll(async () => {
+		({ server, baseUrl } = await startTestServer({ isBunRuntime: false }));
+	});
+
+	afterAll(() => server.close());
+
+	test("GET /skill.md returns 200 with text/markdown", async () => {
+		const res = await fetch(`${baseUrl}/skill.md`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/markdown");
+		const body = await res.text();
+		expect(body).toContain("Test Service");
+	});
+
+	test("GET /llms.txt returns 200 with text/plain", async () => {
+		const res = await fetch(`${baseUrl}/llms.txt`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/plain");
+	});
+
+	test("GET /install.sh returns 501 when CLI not available", async () => {
+		const res = await fetch(`${baseUrl}/install.sh`);
+		expect(res.status).toBe(501);
+		const body = await res.json() as Record<string, unknown>;
+		expect(body["error"]).toContain("CLI not available");
+	});
+});
+
+describe("Express agent routes — building state", () => {
+	let server: Server;
+	let baseUrl: string;
+
+	beforeAll(async () => {
+		({ server, baseUrl } = await startTestServer({
+			isBunRuntime: true,
+			buildFn: () => new Promise(() => {}), // never resolves
+		}));
+	});
+
+	afterAll(() => server.close());
+
+	test("GET /install.sh returns 503 with Retry-After while building", async () => {
+		const res = await fetch(`${baseUrl}/install.sh`);
+		expect(res.status).toBe(503);
+		expect(res.headers.get("retry-after")).toBe("30");
+	});
+
+	test("GET /skill.md returns 200 with fallback content while building", async () => {
+		const res = await fetch(`${baseUrl}/skill.md`);
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).not.toContain("install.sh");
+	});
+});
+
+describe("Express agent routes — failed state", () => {
+	let server: Server;
+	let baseUrl: string;
+
+	beforeAll(async () => {
+		({ server, baseUrl } = await startTestServer({
+			isBunRuntime: true,
+			buildFn: () => Promise.reject(new Error("build failed")),
+		}));
+		await new Promise((r) => setTimeout(r, 10)); // let rejection settle
+	});
+
+	afterAll(() => server.close());
+
+	test("GET /install.sh returns 501 (not 503) when build failed", async () => {
+		const res = await fetch(`${baseUrl}/install.sh`);
+		expect(res.status).toBe(501);
+	});
+});
+
+describe("Express agent routes — ready state", () => {
+	let server: Server;
+	let baseUrl: string;
+
+	beforeAll(async () => {
+		({ server, baseUrl } = await startTestServer({
+			isBunRuntime: true,
+			buildFn: () => Promise.resolve(),
+		}));
+		await new Promise((r) => setTimeout(r, 10)); // let build settle
+	});
+
+	afterAll(() => server.close());
+
+	test("GET /install.sh returns 200 with shell script when ready", async () => {
+		const res = await fetch(`${baseUrl}/install.sh`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/x-shellscript");
+		const body = await res.text();
+		expect(body).toContain("#!/bin/sh");
+	});
+
+	test("GET /skill.md returns CLI-first content when ready", async () => {
+		const res = await fetch(`${baseUrl}/skill.md`);
+		const body = await res.text();
+		expect(body).toContain("install.sh");
+	});
+
+	test("GET /cli/missing-binary returns 404", async () => {
+		const res = await fetch(`${baseUrl}/cli/nonexistent-binary`);
+		expect(res.status).toBe(404);
+	});
+
+	test("GET /cli/ path traversal attempt returns 404 (not a file leak)", async () => {
+		// resolve() will produce an absolute path outside outputDir — existsSync will return false
+		const res = await fetch(`${baseUrl}/cli/..%2F..%2Fetc%2Fpasswd`);
+		// Express decodes %2F as /, which changes the route — either 404 from route mismatch or binary-not-found
+		expect([404, 400]).toContain(res.status);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they pass (they test the shared logic, not yet key0Router)**
+
+```bash
+bun test src/integrations/__tests__/express-agent-routes.test.ts
+```
+
+Expected: all tests pass (the test file builds its own mini Express app from `AgentCliServer` directly).
+
+- [ ] **Step 3: Add routes to `key0Router` in `express.ts`**
+
+Add these imports at the top of `src/integrations/express.ts`:
+
+```typescript
+import { join, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { AgentCliServer } from "./agent-cli-server.js";
+```
+
+At the top of `key0Router()`, after `const router = Router();`:
+
+```typescript
+const agentCli = new AgentCliServer(opts.config);
+```
+
+Add these routes before `return router;` (after the MCP block):
+
+```typescript
+// ── Agent discovery endpoints ────────────────────────────────────────────
+
+router.get("/skill.md", (_req: Request, res: Response) => {
+	res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+	res.send(agentCli.getSkillMd());
+});
+
+router.get("/llms.txt", (_req: Request, res: Response) => {
+	res.setHeader("Content-Type", "text/plain; charset=utf-8");
+	res.send(agentCli.getLlmsTxt());
+});
+
+router.get("/install.sh", (_req: Request, res: Response) => {
+	const state = agentCli.getState();
+	if (state === "not-available" || state === "failed") {
+		return res.status(501).json({
+			error: "CLI not available",
+			hint: state === "not-available" ? "Server is not running on Bun" : "CLI build failed at startup",
+		});
+	}
+	if (!agentCli.isCliReady()) {
+		res.setHeader("Retry-After", "30");
+		return res.status(503).json({ error: "CLI is building", retryAfter: 30 });
+	}
+	res.setHeader("Content-Type", "text/x-shellscript");
+	res.send(agentCli.getInstallSh());
+});
+
+router.get("/cli/:filename", (req: Request, res: Response) => {
+	const state = agentCli.getState();
+	if (state === "not-available" || state === "failed") {
+		return res.status(501).json({ error: "CLI not available" });
+	}
+	if (!agentCli.isCliReady()) {
+		res.setHeader("Retry-After", "30");
+		return res.status(503).json({ error: "CLI is building", retryAfter: 30 });
+	}
+	// Resolve to absolute path — getOutputDir() may return a relative path
+	const filePath = resolve(agentCli.getOutputDir(), req.params.filename as string);
+	if (!existsSync(filePath)) {
+		return res.status(404).json({ error: "Binary not found" });
+	}
+	res.setHeader("Content-Type", "application/octet-stream");
+	res.sendFile(filePath);
+});
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/express.ts src/integrations/__tests__/express-agent-routes.test.ts
+git commit -m "feat(express): mount /skill.md, /llms.txt, /install.sh, /cli/* with route tests"
+```
+
+---
+
+## Task 7: Mount routes in Hono and Fastify
+
+**Files:**
+- Modify: `src/integrations/hono.ts`
+- Modify: `src/integrations/fastify.ts`
+
+The route logic mirrors Express. Use the same state-check pattern: `not-available` or `failed` → 501; `building` → 503 + `Retry-After: 30`; `ready` → serve content.
+
+- [ ] **Step 1: Add routes to Hono**
+
+Add imports at the top of `src/integrations/hono.ts`:
+
+```typescript
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { AgentCliServer } from "./agent-cli-server.js";
+```
+
+At the top of `key0App()`, after `const app = new Hono();`:
+
+```typescript
+const agentCli = new AgentCliServer(opts.config);
+```
+
+Add before `return app;`:
+
+```typescript
+app.get("/skill.md", (c) =>
+	c.body(agentCli.getSkillMd(), 200, { "Content-Type": "text/markdown; charset=utf-8" }),
+);
+
+app.get("/llms.txt", (c) =>
+	c.body(agentCli.getLlmsTxt(), 200, { "Content-Type": "text/plain; charset=utf-8" }),
+);
+
+app.get("/install.sh", (c) => {
+	const state = agentCli.getState();
+	if (state === "not-available" || state === "failed") {
+		return c.json({ error: "CLI not available" }, 501);
+	}
+	if (!agentCli.isCliReady()) {
+		return c.json({ error: "CLI is building", retryAfter: 30 }, 503, { "Retry-After": "30" });
+	}
+	return c.body(agentCli.getInstallSh(), 200, { "Content-Type": "text/x-shellscript" });
+});
+
+app.get("/cli/:filename", (c) => {
+	const state = agentCli.getState();
+	if (state === "not-available" || state === "failed") {
+		return c.json({ error: "CLI not available" }, 501);
+	}
+	if (!agentCli.isCliReady()) {
+		return c.json({ error: "CLI is building", retryAfter: 30 }, 503, { "Retry-After": "30" });
+	}
+	const filePath = resolve(agentCli.getOutputDir(), c.req.param("filename"));
+	if (!existsSync(filePath)) {
+		return c.json({ error: "Binary not found" }, 404);
+	}
+	const data = readFileSync(filePath);
+	return c.body(data, 200, { "Content-Type": "application/octet-stream" });
+});
+```
+
+- [ ] **Step 2: Add routes to Fastify**
+
+Add imports at the top of `src/integrations/fastify.ts`:
+
+```typescript
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { AgentCliServer } from "./agent-cli-server.js";
+```
+
+At the top of `key0Plugin()`, before the first `fastify.get`:
+
+```typescript
+const agentCli = new AgentCliServer(opts.config);
+```
+
+Add after the `/discovery` route:
+
+```typescript
+fastify.get("/skill.md", async (_request, reply) => {
+	reply.header("Content-Type", "text/markdown; charset=utf-8");
+	return reply.send(agentCli.getSkillMd());
+});
+
+fastify.get("/llms.txt", async (_request, reply) => {
+	reply.header("Content-Type", "text/plain; charset=utf-8");
+	return reply.send(agentCli.getLlmsTxt());
+});
+
+fastify.get("/install.sh", async (_request, reply) => {
+	const state = agentCli.getState();
+	if (state === "not-available" || state === "failed") {
+		return reply.status(501).send({ error: "CLI not available" });
+	}
+	if (!agentCli.isCliReady()) {
+		reply.header("Retry-After", "30");
+		return reply.status(503).send({ error: "CLI is building", retryAfter: 30 });
+	}
+	reply.header("Content-Type", "text/x-shellscript");
+	return reply.send(agentCli.getInstallSh());
+});
+
+fastify.get("/cli/:filename", async (request, reply) => {
+	const state = agentCli.getState();
+	if (state === "not-available" || state === "failed") {
+		return reply.status(501).send({ error: "CLI not available" });
+	}
+	if (!agentCli.isCliReady()) {
+		reply.header("Retry-After", "30");
+		return reply.status(503).send({ error: "CLI is building", retryAfter: 30 });
+	}
+	const { filename } = request.params as { filename: string };
+	const filePath = resolve(agentCli.getOutputDir(), filename);
+	if (!existsSync(filePath)) {
+		return reply.status(404).send({ error: "Binary not found" });
+	}
+	reply.header("Content-Type", "application/octet-stream");
+	return reply.send(readFileSync(filePath));
+});
+```
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/integrations/hono.ts src/integrations/fastify.ts
+git commit -m "feat(hono,fastify): mount /skill.md, /llms.txt, /install.sh, /cli/* routes"
+```
+
+---
+
+## Task 8: Docs update
+
+**Files:**
+- Create: `docs/mintlify/guides/agent-experience.mdx`
+- Modify: `docs/mintlify/guides/agent-cli.mdx`
+- Modify: `docs/mintlify/guides/claude-code-integration.mdx`
+
+- [ ] **Step 1: Create `agent-experience.mdx`**
+
+Create `docs/mintlify/guides/agent-experience.mdx`:
+
+```mdx
+---
+title: "Agent Experience"
+description: "What AI agents see when they arrive at your Key0-powered service — and what to put in your README."
+---
+
+Key0 automatically serves endpoints that let AI agents self-onboard at your service with no human in the loop.
+
+## What key0 auto-serves
+
+| Endpoint | Content | Available when |
+|----------|---------|----------------|
+| `GET /skill.md` | CLI install + usage instructions | Always (MCP fallback on Node) |
+| `GET /llms.txt` | Full service description for LLMs | Always |
+| `GET /install.sh` | Platform-detecting install script | Bun server only |
+| `GET /cli/{name}-{platform}` | Pre-built binary download | Bun server only |
+
+No configuration needed. All content is derived from your `SellerConfig`.
+
+## What agents experience
+
+When an AI agent encounters your service URL:
+
+1. Fetches `https://your-service.com/skill.md`
+2. Reads: "install `your-service`, then discover and request"
+3. Runs: `curl -fsSL https://your-service.com/install.sh | sh`
+4. Runs: `your-service discover` → sees plans and pricing
+5. Runs: `your-service request --plan basic` → gets payment challenge
+6. Uses wallet tool (e.g. coinbase-payment-mcp's `make_http_request_with_x402`) → gets signature
+7. Runs: `your-service request --plan basic --payment-signature <sig>` → gets token
+8. Calls your protected API with `Authorization: Bearer <token>`
+
+All without human involvement.
+
+## Copy-paste README block
+
+Add this to your README and website:
+
+```markdown
+## For AI Agents
+
+This API is accessible to AI agents with USDC on Base — no sign-up required.
+
+[![Agent CLI](https://img.shields.io/badge/agent--cli-install-blue)](https://your-service.com/install.sh)
+
+```bash
+curl -fsSL https://your-service.com/install.sh | sh
+your-service discover
+your-service request --plan basic
+```
+
+Agent instructions: https://your-service.com/skill.md
+```
+
+## Claude Code skill file
+
+Generate a skill file and ship it with your docs so Claude Code knows how to use your service automatically:
+
+```typescript
+import { buildCli } from "@key0ai/key0/cli";
+
+const result = await buildCli({
+  name: "your-service",
+  url: "https://your-service.com",
+  discoverConfig: {
+    agentName: "Your Service",
+    agentUrl: "https://your-service.com",
+    agentDescription: "Your service description",
+    plans: [{ planId: "basic", unitAmount: "$0.10" }],
+  },
+});
+// result.claudeSkillMd → drop into .claude/skills/your-service.md
+```
+
+## Node.js servers (manual distribution)
+
+If your server runs on Node.js, auto-build is unavailable. Instead:
+
+1. Run `buildCli()` in a CI step
+2. Upload binaries to a CDN or GitHub Releases
+3. Write a custom `install.sh` pointing to your CDN URLs
+4. Serve `skill.md` statically at your domain root
+```
+
+- [ ] **Step 2: Update `agent-cli.mdx`**
+
+Add this block at the top of the "For Sellers: Generating the Binary" section (before "### 1. Install the CLI builder"):
+
+```mdx
+<Tip>
+**Running on Bun?** You don't need to manually build and distribute binaries. Key0 auto-builds them at startup and serves them at `/install.sh` and `/cli/{name}-{platform}`. See [Agent Experience](/guides/agent-experience).
+
+This guide is for sellers who need CDN distribution (Node.js servers or GitHub Releases).
+</Tip>
+```
+
+- [ ] **Step 3: Update `claude-code-integration.mdx`**
+
+Add before "## Step 1: Install Payments MCP":
+
+```mdx
+## Step 0: Check for agent instructions
+
+If the seller runs Key0 on Bun, they serve ready-made agent instructions:
+
+```bash
+curl https://my-service.example.com/skill.md
+```
+
+If the output contains an `install.sh` line, follow it — the CLI handles everything. Otherwise, continue with the MCP setup below.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/mintlify/guides/agent-experience.mdx docs/mintlify/guides/agent-cli.mdx docs/mintlify/guides/claude-code-integration.mdx
+git commit -m "docs: add agent-experience guide; update agent-cli and claude-code-integration guides"
+```
+
+---
+
+## Task 9: Final checks
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+cd /Users/srijan/Documents/riklr/key0/.worktrees/feat-enable-cli
+bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Lint**
+
+```bash
+bun run lint
+```
+
+Expected: no errors. Fix any before proceeding.
+
+- [ ] **Step 4: Smoke test the example server**
+
+```bash
+cd examples/express-seller
+bun run start &
+sleep 3
+curl -s http://localhost:3000/skill.md | head -5
+curl -s http://localhost:3000/llms.txt | head -3
+# install.sh will be 501 on Node or 503 while building on Bun — both are correct
+curl -sv http://localhost:3000/install.sh 2>&1 | grep "< HTTP"
+kill %1
+```
+
+Expected: `skill.md` and `llms.txt` return content; `/install.sh` returns either 501 or 503 (not 500).
+
+- [ ] **Step 5: Commit any lint/typecheck fixes**
+
+```bash
+git add -p  # stage only the specific fix files, not everything
+git commit -m "fix: address typecheck and lint issues"
+```

--- a/docs/superpowers/specs/2026-03-19-agent-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-19-agent-onboarding-design.md
@@ -1,0 +1,349 @@
+# Agent Onboarding Experience Design
+
+**Date:** 2026-03-19
+**Branch context:** extends `feat/enable-cli`
+**Status:** Approved
+
+---
+
+## Problem
+
+An AI agent (Claude with coinbase-payment-mcp, OpenClaw with a USDC wallet, or any x402-compatible agent) encounters a seller's URL and needs to self-onboard — discover plans, install tooling, pay, and get a token — with no human in the loop.
+
+The trigger is always the same: **agent arrives cold at a URL** (from a README, a tool response, a human message). The agent needs to answer "how do I use this?" entirely from what the server serves.
+
+Today the SDK serves `/discovery`, `/.well-known/agent.json`, and `/.well-known/mcp.json` — but there is no canonical entry point for an agent that doesn't already know which transport to use. There is also no working `/install.sh` (the CLI skill.md references one but it's not served).
+
+---
+
+## Design
+
+### Three new SDK-served endpoints
+
+Mounted by all framework routers — `key0Router` (Express), Hono router, Fastify plugin, and MCP integration. The Docker standalone server inherits them automatically via `key0Router`.
+
+#### `GET /skill.md`
+
+CLI-first agent instructions, generated from `SellerConfig`. This is the canonical cold-arrival entry point — an agent fetching `{agentUrl}/skill.md` gets everything it needs.
+
+Content when `/install.sh` is available (Bun server):
+
+```markdown
+# {agentName}
+
+Install `{binaryName}` to access {agentUrl} autonomously — no API keys, no sign-up.
+
+## Install
+
+```bash
+curl -fsSL {agentUrl}/install.sh | sh
+```
+
+## Usage
+
+```bash
+{binaryName} discover                                            # list plans and pricing
+{binaryName} request --plan <planId>                            # get payment challenge
+{binaryName} request --plan <planId> --payment-signature <sig>  # submit payment proof
+```
+
+Exit code `42` = payment required. Exit code `0` = access granted. All output is JSON.
+
+## Plans
+
+| Plan | Price | Description |
+|------|-------|-------------|
+| {planId} | {unitAmount} | {description} |
+
+## Payment
+
+Use any x402-compatible wallet tool to produce `--payment-signature`.
+With coinbase-payment-mcp: use `make_http_request_with_x402`.
+```
+
+Content when `/install.sh` is not available (Node.js server, Bun absent):
+
+```markdown
+# {agentName}
+
+## Access via MCP
+
+```json
+{ "mcpServers": { "{binaryName}": { "type": "http", "url": "{agentUrl}/mcp" } } }
+```
+
+Use `discover_plans` and `request_access` tools.
+
+## Access via HTTP
+
+Discovery: GET {agentUrl}/discovery
+Payment:   POST {agentUrl}/x402/access
+```
+
+The same generator function (`generateSkillMdContent(config, bunAvailable)`) is used for both the server-served `GET /skill.md` and the static `dist/cli/skill.md` emitted by `buildCli()`. These must never diverge. The existing `generateSkillMd(name, url)` function in `cli.ts` is superseded by `generateSkillMdContent` and removed from the public API.
+
+Content-Type: `text/markdown`.
+
+---
+
+#### `GET /llms.txt`
+
+Follows the [llms.txt convention](https://llmstxt.org). Richer than `/skill.md` — covers all endpoints and the full payment protocol shape. Intended for agents or developers scanning the site to understand the full surface area.
+
+Lines marked **[bun-only]** are emitted only when Bun is available and the CLI has been built. Lines marked **[mcp-only]** are emitted only when `mcp: true` in `SellerConfig`.
+
+```markdown
+# {agentName}
+
+> {agentDescription}
+
+{agentName} is a payment-gated API. Agents pay with USDC on Base; no sign-up required.
+
+## Endpoints
+
+- Discovery: GET {agentUrl}/discovery
+- Payment: POST {agentUrl}/x402/access
+- MCP: {agentUrl}/mcp                               [mcp-only]
+- A2A card: {agentUrl}/.well-known/agent.json
+- Agent instructions: {agentUrl}/skill.md
+- CLI install: curl -fsSL {agentUrl}/install.sh | sh  [bun-only]
+
+## Plans
+
+- {planId}: {unitAmount} — {description}
+
+## Payment flow
+
+1. GET /discovery → see plans, wallet address, chainId
+2. POST /x402/access { planId } → 402 challenge (amount, destination, chainId)
+3. Pay USDC on Base, obtain payment signature from wallet tool
+4. POST /x402/access { planId } + payment-signature header → AccessGrant (JWT, resourceUrl)
+5. Call protected endpoint with Bearer token
+
+## Optional links
+
+- Docs: https://key0.ai/docs
+- Provider: {providerUrl}
+```
+
+Content-Type: `text/plain` (llms.txt convention).
+
+---
+
+#### `GET /install.sh`
+
+Served only when Bun is available **and** the CLI build has completed successfully. Returns `503 Service Unavailable` with `Retry-After: 30` during the startup build window (see Startup behaviour). Returns `501 Not Implemented` if Bun is not in PATH.
+
+Platform-detecting shell script. `{binaryName}` is derived from `agentName` via `slugifyBinaryName()` (defined below). `{agentUrl}` is the seller's public URL.
+
+```sh
+#!/bin/sh
+set -e
+BASE="{agentUrl}/cli"
+ARCH=$(uname -m)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "${OS}_${ARCH}" in
+  darwin_arm64)   BIN="{binaryName}-darwin-arm64" ;;
+  darwin_x86_64)  BIN="{binaryName}-darwin-x64"   ;;
+  linux_x86_64)   BIN="{binaryName}-linux-x64"    ;;
+  *) echo "Unsupported platform: ${OS}_${ARCH}"; exit 1 ;;
+esac
+curl -fsSL "$BASE/$BIN" -o {binaryName}
+chmod +x ./{binaryName}
+./{binaryName} --install
+echo "Installed {binaryName}. Run: {binaryName} discover"
+```
+
+Content-Type: `text/x-shellscript`.
+
+Binary files are served at `GET /cli/{binaryName}-{platform}` — static file routes added alongside `/install.sh`, streaming from `cliOutputDir`.
+
+---
+
+### Slugify algorithm — `slugifyBinaryName(agentName: string): string`
+
+Used to derive the binary name from `agentName`. Must be consistent across all code paths (server startup, `install.sh` generation, `skill.md` generation, binary filenames on disk).
+
+```
+1. Normalize to NFC
+2. Transliterate non-ASCII to nearest ASCII equivalent (e.g. é→e, ü→u); drop if no equivalent
+3. Lowercase
+4. Replace any character that is not [a-z0-9] with a hyphen
+5. Collapse consecutive hyphens to one
+6. Strip leading and trailing hyphens
+7. If result is empty, use "key0-service"
+```
+
+Examples:
+- `"Acme API"` → `"acme-api"`
+- `"My API (v2)"` → `"my-api-v2"`
+- `"Café Data"` → `"cafe-data"`
+- `"  !! bad name !! "` → `"bad-name"`
+
+The slug is computed once at startup from `SellerConfig.agentName` and reused for all requests. It is not recomputed per request.
+
+---
+
+### Startup behaviour (Bun servers)
+
+`key0Router` checks for the Bun runtime at module load time using `typeof Bun !== "undefined"`. This detects whether the server process itself is running under Bun — it does not check whether `bun` is installed on the host. If false, all CLI endpoints (`/install.sh`, `/cli/*`) are not mounted.
+
+If Bun is present:
+
+1. **Before `app.listen()`:** the router initiates `buildCli()` as a background Promise (does not block listen).
+2. **`app.listen()` is called immediately** — the server is ready to handle `/skill.md`, `/llms.txt`, `/discovery`, etc. without delay.
+3. **During the build window** (~15s): `/install.sh` and `/cli/{name}-{platform}` return `503 Service Unavailable` with header `Retry-After: 30` and body `{ "error": "CLI is building", "retryAfter": 30 }`. `/skill.md` returns **`200 OK`** with the MCP fallback content (not 503) — it is always available, just with degraded content during the build window.
+4. **After build completes:** `/install.sh` and `/cli/*` become available. `/skill.md` switches to the CLI-first content.
+5. **If build fails:** same as Bun absent — `/install.sh` and `/cli/*` return `501`. Log the error. `/skill.md` shows MCP fallback.
+
+The build state is held as a module-level variable in the router (not persisted). Every restart rebuilds.
+
+---
+
+### Wiring `SellerConfig` → `buildCli()`
+
+`key0Router` (and equivalent Hono/Fastify routers) derives build params from `SellerConfig` as follows:
+
+```typescript
+buildCli({
+  name: slugifyBinaryName(config.agentName),
+  url: config.agentUrl,           // e.g. "https://api.example.com" — no basePath suffix
+  version: config.version ?? "0.0.0",
+  targets: ["bun-linux-x64", "bun-darwin-arm64", "bun-darwin-x64"],
+  outputDir: config.cliOutputDir ?? "./dist/cli",
+})
+```
+
+Note: `url` is `agentUrl`, not `agentUrl + basePath`. The CLI template calls `/discovery` and `/x402/access` directly on the base URL — these paths are fixed and not affected by `basePath` (which controls the A2A sub-path only).
+
+---
+
+### Two generated artifacts from `buildCli()`
+
+For sellers who want CDN/GitHub Releases distribution (Node.js servers, or preference for external hosting).
+
+#### `dist/cli/skill.md`
+
+Uses the same `generateSkillMdContent(config, bunAvailable: true)` function as the server-served endpoint. Sellers host this at their domain root.
+
+#### `dist/cli/{name}.claude-skill.md`
+
+A Claude Code superpowers-format skill file. Sellers drop this into `.claude/skills/` in their repo or documentation site.
+
+```markdown
+---
+name: {binaryName}
+description: Use when interacting with {agentName} — discover plans, pay with USDC, get access tokens. Trigger on any request to use {agentName} or access {agentUrl}.
+---
+
+You have access to the `{binaryName}` CLI. Use it to interact with {agentName} at {agentUrl}.
+
+## Flow
+
+1. `{binaryName} discover` → see available plans and pricing
+2. `{binaryName} request --plan <planId>` → if exit code is `42`, payment required
+3. Use `make_http_request_with_x402` (coinbase-payment-mcp) with the challenge JSON to obtain a payment signature
+4. `{binaryName} request --plan <planId> --payment-signature <sig>` → exit `0`, returns `{ token, resourceUrl }`
+5. Call `resourceUrl` with `Authorization: Bearer <token>`
+
+All output is JSON. Parse directly — do not screen-scrape.
+If coinbase-payment-mcp is unavailable, check for another x402-compatible wallet tool.
+```
+
+#### `dist/cli/agent-experience.md`
+
+The seller copy-paste block for README and website.
+
+```markdown
+## For AI Agents
+
+This API is accessible to AI agents with USDC on Base — no sign-up required.
+
+[![Agent CLI](https://img.shields.io/badge/agent--cli-install-blue)]({agentUrl}/install.sh)
+
+```bash
+curl -fsSL {agentUrl}/install.sh | sh
+{binaryName} discover
+{binaryName} request --plan {plans[0].planId}
+```
+
+Agent instructions: {agentUrl}/skill.md
+```
+
+---
+
+### Updated `BuildCliResult` type
+
+```typescript
+export interface BuildCliResult {
+  binaries: Array<{
+    path: string;
+    target: string;
+    size: number;
+  }>;
+  skillMd: string;             // path to dist/cli/skill.md
+  claudeSkillMd: string;       // path to dist/cli/{name}.claude-skill.md
+  agentExperienceMd: string;   // path to dist/cli/agent-experience.md
+}
+```
+
+---
+
+### Config changes
+
+#### `SellerConfig` — new optional field
+
+```typescript
+/**
+ * Directory to cache auto-built CLI binaries.
+ * In Docker deployments, use an absolute path (e.g. "/app/dist/cli")
+ * since process.cwd() may not be the project root.
+ * Default: "./dist/cli"
+ */
+cliOutputDir?: string;
+```
+
+No other changes to `SellerConfig`. `/skill.md` and `/llms.txt` are fully derived from existing fields.
+
+---
+
+### Mintlify docs changes
+
+**New page: `guides/agent-experience.mdx`** — "Agent Experience for Sellers"
+
+Sections:
+1. What key0 auto-serves (the three endpoints, content, when each is present)
+2. What agents see step by step (cold arrival → install → discover → pay → token)
+3. The copy-paste "For AI Agents" README block
+4. The Claude Code skill file — where to put it, what it does
+5. Manual distribution fallback (for Node.js servers: run `buildCli()`, upload binaries to a CDN or GitHub Releases, then write a custom `install.sh` pointing to the CDN URLs — key0 does not generate this for the manual path)
+
+**Update `guides/agent-cli.mdx`**
+- Primary path: "binaries are auto-built at startup and served at `/install.sh` on Bun servers — no manual distribution needed"
+- Secondary path (existing): manual `buildCli()` for CDN distribution on Node.js servers
+
+**Update `guides/claude-code-integration.mdx`**
+- Add Step 0: "If the seller exposes a `/skill.md`, Claude Code can onboard without any manual config. Fetch `{seller-url}/skill.md` to see install instructions."
+
+---
+
+## Endpoint summary
+
+| Endpoint | Always served | Bun + build complete | Content-Type |
+|---|---|---|---|
+| `GET /skill.md` | ✅ (MCP fallback) | ✅ (CLI-first) | `text/markdown` |
+| `GET /llms.txt` | ✅ | ✅ | `text/plain` |
+| `GET /install.sh` | — | ✅ | `text/x-shellscript` |
+| `GET /cli/{name}-{platform}` | — | ✅ | `application/octet-stream` |
+
+During startup build window: `/install.sh` and `/cli/*` return `503 Retry-After: 30`. `/skill.md` shows MCP fallback.
+
+---
+
+## Out of scope
+
+- Agent marketplace / registry (seller discovery across domains)
+- Windows support for auto-built CLI
+- Binary signing / notarization
+- Incremental builds (binaries always rebuilt on restart)
+- Custom install.sh templates (e.g. for sellers who want GitHub Releases URLs instead of self-served)

--- a/docs/superpowers/specs/2026-03-19-mpp-native-integration-design.md
+++ b/docs/superpowers/specs/2026-03-19-mpp-native-integration-design.md
@@ -31,6 +31,8 @@ MPP (Machine Payments Protocol) is an IETF-proposed standard that generalises HT
 - Backward compatibility with x402 wire format (no existing sellers).
 - Buyer/client SDK (out of scope per SPEC.md).
 - Subscription/recurring billing.
+- `StripeAdapter` and `LightningAdapter` implementations (architecture defined here; implementations are follow-on specs).
+- Refund flows for non-USDC methods (refund path remains USDC-only for now; non-USDC challenges will be flagged as non-refundable in the audit log).
 
 ---
 
@@ -44,7 +46,9 @@ MPP replaces x402 as the payment negotiation layer only. Everything above it is 
 │                                                      │
 │  • Agent card / A2A discovery                        │
 │  • Plan catalog (planId, unitAmount, description)    │
-│  • State machine (PENDING→PAID→DELIVERED→REFUNDED)   │
+│  • State machine (PENDING→PAID→REFUND_PENDING→       │
+│    REFUNDED|REFUND_FAILED|DELIVERED|EXPIRED|         │
+│    CANCELLED)                                        │
 │  • IChallengeStore / ISeenTxStore / IAuditStore      │
 │  • JWT issuance (AccessTokenIssuer)                  │
 │  • Replay protection (markUsed atomic SET NX)        │
@@ -60,7 +64,7 @@ MPP replaces x402 as the payment negotiation layer only. Everything above it is 
 │  • Authorization: Payment … (credential parsing)     │
 │  • Payment-Receipt: … (optional receipt header)      │
 │  • RFC 9457 Problem Details on failures              │
-│  • IPaymentAdapter per method                        │
+│  • IPaymentAdapter per method, adapter registry      │
 └──────────────────────────────────────────────────────┘
                        ↑
               on-chain / off-chain rails
@@ -69,153 +73,301 @@ MPP replaces x402 as the payment negotiation layer only. Everything above it is 
 │  PAYMENT RAILS (no changes)                          │
 │                                                      │
 │  • USDC on Base — viem verification (today)          │
-│  • Stripe API (new adapter, additive)                │
-│  • Lightning (new adapter, additive)                 │
+│  • Stripe API (new adapter, follow-on spec)          │
+│  • Lightning (new adapter, follow-on spec)           │
 └──────────────────────────────────────────────────────┘
 ```
 
 ---
 
+## Core Types
+
+These types are new or updated and must be defined before implementation begins.
+
+### MppChallengeRequest
+
+The `request` object returned by each adapter — encoded as base64url into the `WWW-Authenticate: Payment request="…"` parameter.
+
+```typescript
+// Each adapter returns its own method-specific request shape.
+// The engine base64url-encodes it for the header.
+type MppChallengeRequest = Record<string, unknown>;
+
+// BaseUsdcAdapter example:
+type BaseUsdcChallengeRequest = {
+  amount: string;       // base units (e.g. "100000" for 0.10 USDC)
+  currency: `0x${string}`; // token contract address
+  recipient: `0x${string}`; // seller wallet
+};
+```
+
+### MppCredentialPayload
+
+The `payload` field inside the decoded `Authorization: Payment` credential. Method-specific.
+
+```typescript
+// Adapter receives this from the decoded credential.
+// BaseUsdcAdapter uses:
+type BaseUsdcCredentialPayload = {
+  txHash: `0x${string}`;
+};
+
+// StripeAdapter would use (per MPP Stripe spec — Shared Payment Token):
+// type StripeCredentialPayload = { spt: string };  // "spt_…"
+```
+
+### MppVerifyParams
+
+Passed to `adapter.verifyCredential()`:
+
+```typescript
+type MppVerifyParams = {
+  challenge: ChallengeRecord;           // server-authoritative stored record
+  credential: {
+    challengeId: string;
+    source: string;                     // payer identity (address, DID, etc.)
+    payload: MppCredentialPayload;      // method-specific proof
+  };
+};
+```
+
+### MppReceiptReference
+
+Returned by `adapter.buildReceiptReference()` — the method-specific reference field only. The engine assembles the full receipt.
+
+```typescript
+type MppReceiptReference = {
+  reference: string;   // "0xtx789…" for USDC, "spt_…" for Stripe, preimage for Lightning
+};
+```
+
+### Updated ChallengeRecord
+
+`ChallengeRecord` gains a `methodData` field to carry method-specific challenge data. Method-agnostic fields (amount in USD cents, planId, expiry, state) remain top-level.
+
+```typescript
+type ChallengeRecord = {
+  // existing method-agnostic fields (unchanged)
+  id: string;
+  requestId: string;
+  planId: string;
+  resourceId: string;
+  amountUsd: string;       // human-readable, e.g. "0.10"
+  expiresAt: Date;
+  state: ChallengeState;
+  createdAt: Date;
+
+  // new
+  method: string;          // "base-usdc" | "stripe" | "lightning" | …
+  methodData: Record<string, unknown>; // method-specific challenge data (raw request object)
+};
+```
+
+The existing USDC-specific fields (`asset: "USDC"`, `chainId: number`, `amountRaw: bigint`) are removed from the top-level record and stored inside `methodData` by `BaseUsdcAdapter`.
+
+### Updated ISeenTxStore
+
+Key relaxed from `0x${string}` to `string` to support non-hex proof references (Stripe SPT, Lightning preimage).
+
+```typescript
+interface ISeenTxStore {
+  get(reference: string): Promise<string | null>;  // returns challengeId that used this reference, or null
+  markUsed(reference: string, challengeId: string): Promise<boolean>;
+}
+```
+
+`get()` is kept (renamed from `get(txHash: \`0x${string}\`)`) so the engine can include the original `challengeId` in double-spend error messages. Existing Redis and Postgres implementations only change the key type annotation — the SET NX logic is identical.
+
+### Adapter Registry
+
+```typescript
+type AdapterRegistry = Map<string, IPaymentAdapter>; // method → adapter
+
+// Built in factory.ts from config.paymentMethods:
+const registry: AdapterRegistry = new Map(
+  config.paymentMethods.map(adapter => [adapter.method, adapter])
+);
+```
+
+The engine receives the registry, not a single adapter.
+
+---
+
 ## IPaymentAdapter — MPP Method Interface
 
-Each adapter maps to one MPP payment method. The interface aligns with MPP's custom method contract.
+Each adapter maps to one MPP payment method.
 
 ```typescript
 interface IPaymentAdapter {
-  readonly method: string;          // "base-usdc", "stripe", "lightning"
+  readonly method: string;           // "base-usdc" | "stripe" | "lightning"
   readonly intent: "charge" | "session";
 
-  // Returns the `request` object encoded in WWW-Authenticate: Payment request="…"
+  // Returns the method-specific request object.
+  // The engine base64url-encodes this into WWW-Authenticate: Payment request="…"
   buildChallengeRequest(params: IssueChallengeParams): Promise<MppChallengeRequest>;
 
-  // Verifies the `payload` from Authorization: Payment credential
+  // Verifies the credential payload against the server-stored challenge.
+  // Must check amount, recipient, and method-specific proof validity.
   verifyCredential(params: MppVerifyParams): Promise<VerificationResult>;
 
-  // Returns the receipt `reference` field (tx hash, PaymentIntent ID, etc.)
-  buildReceipt(result: VerificationResult): MppReceiptReference;
+  // Returns the method-specific payment reference for the receipt.
+  // Engine assembles the full receipt JSON around this.
+  buildReceiptReference(result: VerificationResult): MppReceiptReference;
 }
+```
+
+**Challenge ID generation is the engine's responsibility**, not the adapter's. The engine generates an HMAC-bound `id` over `(realm, method, intent, sha256(request), expires)` after calling `buildChallengeRequest()`.
+
+**Receipt assembly is the engine's responsibility.** The engine calls `buildReceiptReference()` to get the `reference` string, then assembles the full receipt:
+
+```typescript
+const receipt = {
+  challengeId: challenge.id,
+  method: challenge.method,
+  reference: adapter.buildReceiptReference(result).reference,
+  settlement: { amount: challenge.amountUsd, currency: "usd" },
+  status: "success",
+  timestamp: new Date().toISOString(),
+};
 ```
 
 ### BaseUsdcAdapter
 
-Wraps the existing `X402Adapter` viem verification logic. The on-chain code is unchanged — only the envelope changes.
+Wraps the existing `X402Adapter` viem verification logic. On-chain verification code is unchanged.
 
 ```typescript
 class BaseUsdcAdapter implements IPaymentAdapter {
   readonly method = "base-usdc";  // custom MPP method — Key0 publishes the spec
   readonly intent = "charge";
 
-  buildChallengeRequest({ amount, walletAddress }) {
+  buildChallengeRequest({ amount, destination }) {  // IssueChallengeParams fields: amount (USD string), destination (wallet address)
     return {
-      amount: toBaseUnits(amount),
-      currency: USDC_ADDRESS,       // 0x833589f… on mainnet
-      recipient: walletAddress,
+      amount: toUsdcBaseUnits(amount),  // e.g. "100000" for $0.10
+      currency: USDC_ADDRESS,           // 0x833589f… on mainnet
+      recipient: destination,
     };
   }
 
-  verifyCredential({ payload, challenge }) {
-    // identical to current X402Adapter viem verification
-    return this.verifyTransfer(payload.txHash, challenge);
+  verifyCredential({ challenge, credential }) {
+    const { txHash } = credential.payload as BaseUsdcCredentialPayload;
+    // identical viem ERC-20 Transfer verification as current X402Adapter
+    return this.verifyTransfer(txHash, challenge.methodData);
   }
 
-  buildReceipt({ txHash }) {
+  buildReceiptReference({ txHash }) {
     return { reference: txHash };
   }
 }
 ```
 
-**Note:** `base-usdc` is a custom MPP method. Key0 must publish its request/payload schemas as a method spec so external MPP clients can implement it. Ideally, Key0 contributes a `base-usdc` client implementation to `mppx` so agents using that SDK can pay Key0 sellers automatically.
+**Note on `base-usdc` as a custom method:**
+`base-usdc` is not a defined MPP method. Key0 must publish a `base-usdc` method spec (request schema, payload schema, verification procedure) so external MPP clients can implement it. Ideally, Key0 contributes a `base-usdc` client handler to `mppx` so agents using that SDK can pay Key0 sellers automatically with zero custom code.
 
-### StripeAdapter (future)
+### StripeAdapter (architecture only — implementation is a follow-on spec)
 
-Must conform to MPP's existing `stripe` method spec (not invent its own). This gives automatic compatibility with any MPP client that already knows `stripe`.
+**Important:** The MPP `stripe` method uses Shared Payment Tokens (SPT), not `clientSecret` or `paymentIntentId`. The MPP Stripe charge spec defines specific `request` fields (`amount`, `currency`, `decimals`, `methodDetails.networkId`, `methodDetails.paymentMethodTypes`) and a credential `payload` of `{ spt: string }`. Any `StripeAdapter` implementation must conform to that spec exactly. Do not implement Stripe until the follow-on spec is written against the actual MPP Stripe method schema.
 
-```typescript
-class StripeAdapter implements IPaymentAdapter {
-  readonly method = "stripe";   // MPP-defined method — must follow MPP's stripe schemas
-  readonly intent = "charge";
+### LightningAdapter (architecture only — implementation is a follow-on spec)
 
-  buildChallengeRequest({ amount }) {
-    const intent = await stripe.paymentIntents.create({ amount, currency: "usd" });
-    return { clientSecret: intent.client_secret, amount };
-  }
-
-  verifyCredential({ payload }) {
-    const intent = await stripe.paymentIntents.retrieve(payload.paymentIntentId);
-    return { success: intent.status === "succeeded" };
-  }
-
-  buildReceipt({ paymentIntentId }) {
-    return { reference: paymentIntentId };
-  }
-}
-```
+Similarly deferred. Lightning credential payload contains a preimage. Follow-on spec must define the full method schema.
 
 ---
 
 ## Challenge Engine Changes
 
-### Issuing challenges (402 path)
+### Updated constructor
 
-The engine iterates all enabled adapters, calls `buildChallengeRequest()` on each, stores one challenge record per method, and emits one `WWW-Authenticate: Payment` header per method.
+```typescript
+type ChallengeEngineConfig = {
+  adapters: AdapterRegistry;   // replaces singular `adapter`
+  store: IChallengeStore;
+  seenTxStore: ISeenTxStore;
+  auditStore?: IAuditStore;
+  tokenIssuer: IAccessTokenIssuer;
+  sellerConfig: SellerConfig;
+};
+```
+
+### Issuing challenges (402 path)
 
 ```
 Incoming request (no credential)
          ↓
-for each adapter in config.paymentMethods:
-  buildChallengeRequest() → request object
-  generate HMAC-bound challenge id
-  IChallengeStore.store(challenge)
-  build WWW-Authenticate: Payment header string
+for each adapter in adapters (plan's allowed methods if restricted):
+  request = await adapter.buildChallengeRequest(params)
+  id = hmac(realm, method, intent, sha256(request), expires)
+  store challenge: { id, method, methodData: request, amountUsd, planId, … }
+  build WWW-Authenticate header string
          ↓
 HTTP/1.1 402 Payment Required
 Cache-Control: no-store
 Content-Type: application/problem+json
-WWW-Authenticate: Payment id="abc", method="base-usdc", intent="charge", realm="…", expires="…", request="eyJ…"
-WWW-Authenticate: Payment id="def", method="stripe",   intent="charge", realm="…", expires="…", request="eyJ…"
+WWW-Authenticate: Payment id="abc", method="base-usdc", intent="charge", realm="<config.agentUrl>", expires="…", request="eyJ…"
+WWW-Authenticate: Payment id="def", method="stripe",   intent="charge", realm="<config.agentUrl>", expires="…", request="eyJ…"
 
 { "type": "https://paymentauth.org/problems/payment-required", "status": 402 }
 ```
 
-Challenge IDs are HMAC-bound to their parameters (realm, method, intent, request hash, expires) to prevent clients from reusing an ID with modified payment terms.
+`realm` is always `config.agentUrl` (the seller's agent base URL).
 
 ### Verifying credentials (retry path)
 
 ```
-Incoming request
 Authorization: Payment <base64url>
          ↓
-Decode → extract challenge.method
-Look up stored challenge by challenge.id
-Assert challenge.method === credential.challenge.method
-Route to matching adapter.verifyCredential()
+Decode → { challenge: { id, method, … }, source, payload }
+Look up STORED challenge by challenge.id from IChallengeStore
+Assert stored.method === credential.challenge.method    ← compare against server record, not credential claim
+Assert stored.method maps to a registered adapter
+Route to adapter = adapters.get(stored.method)
          ↓
-VerificationResult { success: true }
+result = await adapter.verifyCredential({ challenge: stored, credential })
          ↓
-IChallengeStore.transition(id, PENDING → PAID)      ← unchanged
-ISeenTxStore.markUsed(reference, challengeId)       ← unchanged, replay protection
+ISeenTxStore.markUsed(result.reference, stored.id)     ← reference is string (not 0x${string})
+IChallengeStore.transition(stored.id, PENDING → PAID)
          ↓
-fetchResourceCredentials() → JWT                    ← unchanged
+fetchResourceCredentials() → JWT
+         ↓
+receipt = engine.assembleReceipt(stored, adapter.buildReceiptReference(result))
          ↓
 HTTP/1.1 200 OK
-Payment-Receipt: eyJ…                               ← new header
-Authorization: Bearer <jwt>                         ← unchanged
+Payment-Receipt: <base64url(receipt)>
+Authorization: Bearer <jwt>
+```
+
+**Security note on method assertion:** The assertion is `stored.method === credential.challenge.method`, where `stored` is the authoritative server-side record. This prevents a client from submitting a credential for a cheap method (e.g., Stripe) against a challenge originally issued for an expensive method (e.g., USDC), because the stored record is the ground truth.
+
+### Updated `processHttpPayment` signature
+
+```typescript
+// Before (USDC-specific)
+processHttpPayment(requestId, planId, resourceId, txHash: `0x${string}`, fromAddress?)
+
+// After (method-agnostic)
+processHttpPayment(requestId: string, mppCredential: MppCredential): Promise<AccessGrant>
+
+type MppCredential = {
+  challenge: { id: string; method: string; intent: string; request: string; expires?: string };
+  source: string;
+  payload: Record<string, unknown>;
+};
 ```
 
 ### What is unchanged in the engine
 
-- `PENDING → PAID → DELIVERED → REFUNDED` state machine
+- All state transitions (`PENDING → PAID → DELIVERED`, `REFUND_PENDING → REFUNDED|REFUND_FAILED`, etc.)
 - `IChallengeStore.transition()` atomic compare-and-swap
-- `ISeenTxStore.markUsed()` double-spend prevention
+- `ISeenTxStore.markUsed()` logic (only key type broadened to `string`)
 - `fetchResourceCredentials()` JWT issuance
 - `onPaymentReceived` / `onChallengeExpired` hooks
 - Expiry and idempotency logic
+- Refund path remains USDC-only (non-USDC challenges are flagged `nonRefundable: true` in `methodData`)
 
 ---
 
 ## Seller Config API
 
-`paymentMethods` is a required field. Sellers must be explicit — no defaults, no fallbacks.
+`paymentMethods` is required. Sellers must be explicit — no defaults, no fallbacks.
 
 ```typescript
 import { createKey0, baseUsdc, stripe, lightning } from "@key0ai/key0";
@@ -225,7 +377,7 @@ createKey0({
   network: "mainnet",
   plans: [
     { planId: "basic",   unitAmount: "0.10" },
-    { planId: "premium", unitAmount: "5.00" },
+    { planId: "premium", unitAmount: "5.00", methods: ["base-usdc"] }, // crypto only
   ],
   paymentMethods: [
     baseUsdc(),
@@ -240,33 +392,26 @@ Factory function signatures:
 
 ```typescript
 baseUsdc(options?: {
-  network?: "mainnet" | "testnet";   // inherits from SellerConfig if omitted
+  network?: "mainnet" | "testnet";  // inherits from SellerConfig if omitted
   mode?: "pull" | "push";
-})
+}): IPaymentAdapter
 
 stripe(options: {
   secretKey: string;
   webhookSecret?: string;
-})
+}): IPaymentAdapter
 
 lightning(options: {
   node: string;
   macaroon: string;
-})
+}): IPaymentAdapter
 ```
 
-Each factory returns a configured `IPaymentAdapter` instance. Sellers never instantiate adapter classes directly.
+Each factory returns a configured `IPaymentAdapter`. Sellers never instantiate adapter classes directly. The `createKey0` factory builds the `AdapterRegistry` from `paymentMethods` and injects it into the engine.
 
 **Plan-level method restriction (optional):**
 
-```typescript
-plans: [
-  { planId: "basic",   unitAmount: "0.10" },                          // all methods
-  { planId: "premium", unitAmount: "5.00", methods: ["base-usdc"] }, // crypto only
-],
-```
-
-When the engine issues challenges for a restricted plan, it only iterates adapters in the plan's `methods` list.
+When a plan specifies `methods: ["base-usdc"]`, the engine only iterates adapters whose `method` is in that list when issuing challenges for that plan.
 
 ---
 
@@ -274,28 +419,31 @@ When the engine issues challenges for a restricted plan, it only iterates adapte
 
 ### HTTP integrations (Express, Hono, Fastify)
 
-Unified pattern across all three frameworks:
+Unified flow across all three frameworks:
 
 ```
 Incoming request
       ↓
-Does Authorization: Payment header exist?
-      ├── No  → engine.requestHttpAccess() → WWW-Authenticate headers → 402
-      └── Yes → decode base64url credential
-                 extract challenge.id + challenge.method
-                 engine.processHttpPayment() → 200 + Payment-Receipt + JWT
+Authorization: Payment header present?
+      ├── No  → engine.requestHttpAccess() → emit WWW-Authenticate headers → 402
+      └── Yes → decode base64url → MppCredential
+                 engine.processHttpPayment(requestId, mppCredential)
+                 200 + Payment-Receipt header + JWT
 ```
 
 **RFC 9457 error bodies on all 402 responses:**
 
-| Condition | Problem type URI |
-|---|---|
-| No credential | `payment-required` |
-| Expired challenge | `payment-expired` |
-| Already-used reference | `invalid-challenge` |
-| Amount too low | `payment-insufficient` |
-| Bad credential JSON | `malformed-credential` |
-| On-chain verify failed | `verification-failed` |
+| Condition | Problem type | Status |
+|---|---|---|
+| No credential | `payment-required` | 402 |
+| Expired challenge | `payment-expired` | 402 |
+| Already-used reference | `invalid-challenge` | 402 |
+| Amount too low | `payment-insufficient` | 402 |
+| Bad credential JSON | `malformed-credential` | 402 |
+| On-chain verify failed | `verification-failed` | 402 |
+| Method not in adapter registry | `method-unsupported` | 400 |
+
+`method-unsupported` returns 400, not 402, because the client cannot retry with payment — the method is simply not accepted.
 
 ### MCP integration
 
@@ -327,16 +475,16 @@ Replaces Key0's custom `isError`/`structuredContent` signalling with the MPP sta
     "arguments": { … },
     "_meta": {
       "org.paymentauth/credential": {
-        "challenge": { … },
+        "challenge": { "id": "…", "method": "base-usdc", … },
         "source": "0x…",
-        "payload": { … }
+        "payload": { "txHash": "0x…" }
       }
     }
   }
 }
 ```
 
-**Receipt (server → agent):** `_meta["org.paymentauth/receipt"]`
+**Receipt (server → agent):** `_meta["org.paymentauth/receipt"]` — full structure including `reference` and `settlement`:
 
 ```json
 {
@@ -344,9 +492,12 @@ Replaces Key0's custom `isError`/`structuredContent` signalling with the MPP sta
     "content": [ … ],
     "_meta": {
       "org.paymentauth/receipt": {
-        "status": "success",
         "challengeId": "…",
-        "method": "base-usdc"
+        "method": "base-usdc",
+        "reference": "0xtx789…",
+        "settlement": { "amount": "0.10", "currency": "usd" },
+        "status": "success",
+        "timestamp": "2026-03-19T12:00:00Z"
       }
     }
   }
@@ -357,16 +508,14 @@ Replaces Key0's custom `isError`/`structuredContent` signalling with the MPP sta
 
 ## Security Invariants (unchanged)
 
-All existing Key0 security invariants are preserved and remain aligned with MPP's requirements:
-
 | Invariant | MPP Requirement | Key0 Implementation |
 |---|---|---|
-| Single-use proofs | Credentials valid exactly once | `ISeenTxStore.markUsed()` atomic SET NX |
+| Single-use proofs | Credentials valid exactly once | `ISeenTxStore.markUsed()` atomic SET NX — key broadened to `string` |
 | No side effects before payment | Servers must not modify state for unpaid requests | `preSettlementCheck()` guard |
-| Challenge binding | `id` cryptographically bound to parameters | HMAC-bound challenge IDs |
+| Challenge binding | `id` cryptographically bound to parameters | HMAC over `(realm, method, intent, sha256(request), expires)` |
+| Method assertion | Credential method verified against server record | `stored.method === credential.challenge.method` — stored record is ground truth |
 | TLS required | TLS 1.2+ for all payment flows | Standard HTTPS deployment |
 | No credential logging | Credentials must not appear in logs | Key0 does not log raw credentials |
-| Replay protection | Same proof cannot be reused | `ISeenTxStore` + state machine |
 
 ---
 
@@ -374,22 +523,27 @@ All existing Key0 security invariants are preserved and remain aligned with MPP'
 
 | File | Change |
 |---|---|
-| `src/types/index.ts` | Update `IPaymentAdapter` to MPP method interface |
-| `src/adapter/index.ts` | Rename/refactor `X402Adapter` → `BaseUsdcAdapter` |
-| `src/core/challenge-engine.ts` | Multi-adapter iteration on 402 path; method routing on credential path |
-| `src/integrations/settlement.ts` | Replace `buildHttpPaymentRequirements` with MPP header builder; replace `decodePaymentSignature` with MPP credential decoder |
-| `src/integrations/express.ts` | Parse `Authorization: Payment`; emit `WWW-Authenticate: Payment`; RFC 9457 errors |
+| `src/types/index.ts` | Add `MppChallengeRequest`, `MppVerifyParams`, `MppCredentialPayload`, `MppReceiptReference`, `MppCredential`, `AdapterRegistry`; update `IPaymentAdapter`; update `ISeenTxStore` key type to `string` (keep `get()`, rename from `get(txHash)`); update `ChallengeRecord` with `method` + `methodData`, remove top-level USDC fields |
+| `src/types/adapter.ts` | `IssueChallengeParams` fields confirmed as `amount: string` (USD) and `destination: \`0x${string}\`` — no rename needed; verify these match `BaseUsdcAdapter.buildChallengeRequest` usage |
+| `src/types/x402-extension.ts` | Delete — all x402-specific types removed |
+| `src/adapter/index.ts` | Rename `X402Adapter` → `BaseUsdcAdapter`; conform to new `IPaymentAdapter` |
+| `src/core/challenge-engine.ts` | Accept `AdapterRegistry` (not single adapter); multi-adapter iteration on 402 path; method routing + stored-record assertion on credential path; new `processHttpPayment(requestId, MppCredential)` signature; engine-assembled receipts |
+| `src/integrations/settlement.ts` | Replace `buildHttpPaymentRequirements` with MPP `WWW-Authenticate` header builder; replace `decodePaymentSignature` with MPP credential decoder (`base64url` → `MppCredential`) |
+| `src/integrations/express.ts` | Parse `Authorization: Payment`; emit `WWW-Authenticate: Payment`; RFC 9457 errors including `method-unsupported` (400) |
 | `src/integrations/hono.ts` | Same as Express |
 | `src/integrations/fastify.ts` | Same as Express |
-| `src/integrations/mcp.ts` | Replace `isError`/`structuredContent` with `-32042` + `_meta` |
-| `src/factory.ts` | Add `paymentMethods` to `SellerConfig`; wire adapter registry |
-| `src/index.ts` | Export `baseUsdc`, `stripe`, `lightning` factory functions |
+| `src/integrations/mcp.ts` | Replace `isError`/`structuredContent` with `-32042` + `_meta`; full receipt structure in result `_meta` |
+| `src/factory.ts` | `paymentMethods: IPaymentAdapter[]` required in `SellerConfig`; build `AdapterRegistry` and inject into engine |
+| `src/executor.ts` | Review A2A path types (`X402Challenge`, `PaymentProof`) — update or isolate USDC-specific fields into `base-usdc` method; A2A path remains USDC-only for now |
+| `src/index.ts` | Export `baseUsdc`, `stripe`, `lightning` factory functions; remove x402 exports |
+| `src/storage/` | Update `ISeenTxStore` key type to `string` in Redis + Postgres implementations |
 
 ---
 
 ## Out of Scope for This Spec
 
-- `StripeAdapter` implementation (architecture is defined; implementation is a follow-on)
-- `LightningAdapter` implementation (same)
+- `StripeAdapter` implementation (must be written against actual MPP Stripe method spec — SPT-based, not `clientSecret`)
+- `LightningAdapter` implementation
 - Publishing `base-usdc` method spec to MPP ecosystem / contributing to `mppx`
+- Refund flows for non-USDC payment methods
 - Client SDK for paying Key0-protected APIs

--- a/docs/superpowers/specs/2026-03-19-mpp-native-integration-design.md
+++ b/docs/superpowers/specs/2026-03-19-mpp-native-integration-design.md
@@ -1,0 +1,395 @@
+# MPP Native Integration — Design Spec
+
+**Date:** 2026-03-19
+**Branch:** feat/mpp
+**Status:** Draft
+
+---
+
+## Problem Statement
+
+Key0 today uses the x402 protocol for payment negotiation. x402 is a Coinbase-specific wire format that only accepts USDC on Base. This creates two hard blockers for API sellers:
+
+1. **Interoperability:** Only agents that implement Key0's custom x402 flow can pay. Any agent built on `mppx` or another MPP-compliant SDK cannot pay a Key0-protected API without custom integration work.
+
+2. **Single payment rail:** Sellers can only receive USDC on Base. Agents without a crypto wallet — paying via Stripe, card, or Lightning — cannot access Key0-protected APIs at all.
+
+MPP (Machine Payments Protocol) is an IETF-proposed standard that generalises HTTP 402 payment negotiation to be payment-rail agnostic. It solves both problems simultaneously.
+
+---
+
+## Goals
+
+- Any MPP-compliant agent can pay a Key0-protected API out of the box.
+- Sellers can accept multiple payment methods (USDC on Base, Stripe, Lightning) from a single endpoint.
+- Sellers explicitly declare which payment methods they accept at config time.
+- Key0's internal value-add (state machine, JWT issuance, audit trail, replay protection, A2A discovery) is unaffected.
+- The on-chain USDC/Base verification logic is preserved exactly as-is.
+
+## Non-Goals
+
+- Backward compatibility with x402 wire format (no existing sellers).
+- Buyer/client SDK (out of scope per SPEC.md).
+- Subscription/recurring billing.
+
+---
+
+## Layer Architecture
+
+MPP replaces x402 as the payment negotiation layer only. Everything above it is unchanged.
+
+```
+┌──────────────────────────────────────────────────────┐
+│  KEY0 VALUE-ADD LAYER (no changes)                   │
+│                                                      │
+│  • Agent card / A2A discovery                        │
+│  • Plan catalog (planId, unitAmount, description)    │
+│  • State machine (PENDING→PAID→DELIVERED→REFUNDED)   │
+│  • IChallengeStore / ISeenTxStore / IAuditStore      │
+│  • JWT issuance (AccessTokenIssuer)                  │
+│  • Replay protection (markUsed atomic SET NX)        │
+│  • onPaymentReceived / onChallengeExpired hooks      │
+└──────────────────────────────────────────────────────┘
+                       ↑
+              verified payment event
+                       ↑
+┌──────────────────────────────────────────────────────┐
+│  MPP PAYMENT NEGOTIATION LAYER (replaces x402)       │
+│                                                      │
+│  • WWW-Authenticate: Payment … (challenge headers)   │
+│  • Authorization: Payment … (credential parsing)     │
+│  • Payment-Receipt: … (optional receipt header)      │
+│  • RFC 9457 Problem Details on failures              │
+│  • IPaymentAdapter per method                        │
+└──────────────────────────────────────────────────────┘
+                       ↑
+              on-chain / off-chain rails
+                       ↑
+┌──────────────────────────────────────────────────────┐
+│  PAYMENT RAILS (no changes)                          │
+│                                                      │
+│  • USDC on Base — viem verification (today)          │
+│  • Stripe API (new adapter, additive)                │
+│  • Lightning (new adapter, additive)                 │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## IPaymentAdapter — MPP Method Interface
+
+Each adapter maps to one MPP payment method. The interface aligns with MPP's custom method contract.
+
+```typescript
+interface IPaymentAdapter {
+  readonly method: string;          // "base-usdc", "stripe", "lightning"
+  readonly intent: "charge" | "session";
+
+  // Returns the `request` object encoded in WWW-Authenticate: Payment request="…"
+  buildChallengeRequest(params: IssueChallengeParams): Promise<MppChallengeRequest>;
+
+  // Verifies the `payload` from Authorization: Payment credential
+  verifyCredential(params: MppVerifyParams): Promise<VerificationResult>;
+
+  // Returns the receipt `reference` field (tx hash, PaymentIntent ID, etc.)
+  buildReceipt(result: VerificationResult): MppReceiptReference;
+}
+```
+
+### BaseUsdcAdapter
+
+Wraps the existing `X402Adapter` viem verification logic. The on-chain code is unchanged — only the envelope changes.
+
+```typescript
+class BaseUsdcAdapter implements IPaymentAdapter {
+  readonly method = "base-usdc";  // custom MPP method — Key0 publishes the spec
+  readonly intent = "charge";
+
+  buildChallengeRequest({ amount, walletAddress }) {
+    return {
+      amount: toBaseUnits(amount),
+      currency: USDC_ADDRESS,       // 0x833589f… on mainnet
+      recipient: walletAddress,
+    };
+  }
+
+  verifyCredential({ payload, challenge }) {
+    // identical to current X402Adapter viem verification
+    return this.verifyTransfer(payload.txHash, challenge);
+  }
+
+  buildReceipt({ txHash }) {
+    return { reference: txHash };
+  }
+}
+```
+
+**Note:** `base-usdc` is a custom MPP method. Key0 must publish its request/payload schemas as a method spec so external MPP clients can implement it. Ideally, Key0 contributes a `base-usdc` client implementation to `mppx` so agents using that SDK can pay Key0 sellers automatically.
+
+### StripeAdapter (future)
+
+Must conform to MPP's existing `stripe` method spec (not invent its own). This gives automatic compatibility with any MPP client that already knows `stripe`.
+
+```typescript
+class StripeAdapter implements IPaymentAdapter {
+  readonly method = "stripe";   // MPP-defined method — must follow MPP's stripe schemas
+  readonly intent = "charge";
+
+  buildChallengeRequest({ amount }) {
+    const intent = await stripe.paymentIntents.create({ amount, currency: "usd" });
+    return { clientSecret: intent.client_secret, amount };
+  }
+
+  verifyCredential({ payload }) {
+    const intent = await stripe.paymentIntents.retrieve(payload.paymentIntentId);
+    return { success: intent.status === "succeeded" };
+  }
+
+  buildReceipt({ paymentIntentId }) {
+    return { reference: paymentIntentId };
+  }
+}
+```
+
+---
+
+## Challenge Engine Changes
+
+### Issuing challenges (402 path)
+
+The engine iterates all enabled adapters, calls `buildChallengeRequest()` on each, stores one challenge record per method, and emits one `WWW-Authenticate: Payment` header per method.
+
+```
+Incoming request (no credential)
+         ↓
+for each adapter in config.paymentMethods:
+  buildChallengeRequest() → request object
+  generate HMAC-bound challenge id
+  IChallengeStore.store(challenge)
+  build WWW-Authenticate: Payment header string
+         ↓
+HTTP/1.1 402 Payment Required
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Payment id="abc", method="base-usdc", intent="charge", realm="…", expires="…", request="eyJ…"
+WWW-Authenticate: Payment id="def", method="stripe",   intent="charge", realm="…", expires="…", request="eyJ…"
+
+{ "type": "https://paymentauth.org/problems/payment-required", "status": 402 }
+```
+
+Challenge IDs are HMAC-bound to their parameters (realm, method, intent, request hash, expires) to prevent clients from reusing an ID with modified payment terms.
+
+### Verifying credentials (retry path)
+
+```
+Incoming request
+Authorization: Payment <base64url>
+         ↓
+Decode → extract challenge.method
+Look up stored challenge by challenge.id
+Assert challenge.method === credential.challenge.method
+Route to matching adapter.verifyCredential()
+         ↓
+VerificationResult { success: true }
+         ↓
+IChallengeStore.transition(id, PENDING → PAID)      ← unchanged
+ISeenTxStore.markUsed(reference, challengeId)       ← unchanged, replay protection
+         ↓
+fetchResourceCredentials() → JWT                    ← unchanged
+         ↓
+HTTP/1.1 200 OK
+Payment-Receipt: eyJ…                               ← new header
+Authorization: Bearer <jwt>                         ← unchanged
+```
+
+### What is unchanged in the engine
+
+- `PENDING → PAID → DELIVERED → REFUNDED` state machine
+- `IChallengeStore.transition()` atomic compare-and-swap
+- `ISeenTxStore.markUsed()` double-spend prevention
+- `fetchResourceCredentials()` JWT issuance
+- `onPaymentReceived` / `onChallengeExpired` hooks
+- Expiry and idempotency logic
+
+---
+
+## Seller Config API
+
+`paymentMethods` is a required field. Sellers must be explicit — no defaults, no fallbacks.
+
+```typescript
+import { createKey0, baseUsdc, stripe, lightning } from "@key0ai/key0";
+
+createKey0({
+  walletAddress: "0x…",
+  network: "mainnet",
+  plans: [
+    { planId: "basic",   unitAmount: "0.10" },
+    { planId: "premium", unitAmount: "5.00" },
+  ],
+  paymentMethods: [
+    baseUsdc(),
+    stripe({ secretKey: "sk_live_…" }),
+    lightning({ node: "…", macaroon: "…" }),
+  ],
+  fetchResourceCredentials: async ({ planId }) => { … },
+});
+```
+
+Factory function signatures:
+
+```typescript
+baseUsdc(options?: {
+  network?: "mainnet" | "testnet";   // inherits from SellerConfig if omitted
+  mode?: "pull" | "push";
+})
+
+stripe(options: {
+  secretKey: string;
+  webhookSecret?: string;
+})
+
+lightning(options: {
+  node: string;
+  macaroon: string;
+})
+```
+
+Each factory returns a configured `IPaymentAdapter` instance. Sellers never instantiate adapter classes directly.
+
+**Plan-level method restriction (optional):**
+
+```typescript
+plans: [
+  { planId: "basic",   unitAmount: "0.10" },                          // all methods
+  { planId: "premium", unitAmount: "5.00", methods: ["base-usdc"] }, // crypto only
+],
+```
+
+When the engine issues challenges for a restricted plan, it only iterates adapters in the plan's `methods` list.
+
+---
+
+## Integration Layer
+
+### HTTP integrations (Express, Hono, Fastify)
+
+Unified pattern across all three frameworks:
+
+```
+Incoming request
+      ↓
+Does Authorization: Payment header exist?
+      ├── No  → engine.requestHttpAccess() → WWW-Authenticate headers → 402
+      └── Yes → decode base64url credential
+                 extract challenge.id + challenge.method
+                 engine.processHttpPayment() → 200 + Payment-Receipt + JWT
+```
+
+**RFC 9457 error bodies on all 402 responses:**
+
+| Condition | Problem type URI |
+|---|---|
+| No credential | `payment-required` |
+| Expired challenge | `payment-expired` |
+| Already-used reference | `invalid-challenge` |
+| Amount too low | `payment-insufficient` |
+| Bad credential JSON | `malformed-credential` |
+| On-chain verify failed | `verification-failed` |
+
+### MCP integration
+
+Replaces Key0's custom `isError`/`structuredContent` signalling with the MPP standard.
+
+**Challenge (server → agent):** JSON-RPC error code `-32042`
+
+```json
+{
+  "code": -32042,
+  "message": "Payment Required",
+  "data": {
+    "httpStatus": 402,
+    "challenges": [
+      { "id": "…", "method": "base-usdc", "intent": "charge", "request": { … } },
+      { "id": "…", "method": "stripe",   "intent": "charge", "request": { … } }
+    ]
+  }
+}
+```
+
+**Credential (agent → server):** `_meta["org.paymentauth/credential"]`
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "…",
+    "arguments": { … },
+    "_meta": {
+      "org.paymentauth/credential": {
+        "challenge": { … },
+        "source": "0x…",
+        "payload": { … }
+      }
+    }
+  }
+}
+```
+
+**Receipt (server → agent):** `_meta["org.paymentauth/receipt"]`
+
+```json
+{
+  "result": {
+    "content": [ … ],
+    "_meta": {
+      "org.paymentauth/receipt": {
+        "status": "success",
+        "challengeId": "…",
+        "method": "base-usdc"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Security Invariants (unchanged)
+
+All existing Key0 security invariants are preserved and remain aligned with MPP's requirements:
+
+| Invariant | MPP Requirement | Key0 Implementation |
+|---|---|---|
+| Single-use proofs | Credentials valid exactly once | `ISeenTxStore.markUsed()` atomic SET NX |
+| No side effects before payment | Servers must not modify state for unpaid requests | `preSettlementCheck()` guard |
+| Challenge binding | `id` cryptographically bound to parameters | HMAC-bound challenge IDs |
+| TLS required | TLS 1.2+ for all payment flows | Standard HTTPS deployment |
+| No credential logging | Credentials must not appear in logs | Key0 does not log raw credentials |
+| Replay protection | Same proof cannot be reused | `ISeenTxStore` + state machine |
+
+---
+
+## Files Affected
+
+| File | Change |
+|---|---|
+| `src/types/index.ts` | Update `IPaymentAdapter` to MPP method interface |
+| `src/adapter/index.ts` | Rename/refactor `X402Adapter` → `BaseUsdcAdapter` |
+| `src/core/challenge-engine.ts` | Multi-adapter iteration on 402 path; method routing on credential path |
+| `src/integrations/settlement.ts` | Replace `buildHttpPaymentRequirements` with MPP header builder; replace `decodePaymentSignature` with MPP credential decoder |
+| `src/integrations/express.ts` | Parse `Authorization: Payment`; emit `WWW-Authenticate: Payment`; RFC 9457 errors |
+| `src/integrations/hono.ts` | Same as Express |
+| `src/integrations/fastify.ts` | Same as Express |
+| `src/integrations/mcp.ts` | Replace `isError`/`structuredContent` with `-32042` + `_meta` |
+| `src/factory.ts` | Add `paymentMethods` to `SellerConfig`; wire adapter registry |
+| `src/index.ts` | Export `baseUsdc`, `stripe`, `lightning` factory functions |
+
+---
+
+## Out of Scope for This Spec
+
+- `StripeAdapter` implementation (architecture is defined; implementation is a follow-on)
+- `LightningAdapter` implementation (same)
+- Publishing `base-usdc` method spec to MPP ecosystem / contributing to `mppx`
+- Client SDK for paying Key0-protected APIs

--- a/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
+++ b/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
@@ -234,58 +234,172 @@ This mode remains HTTP-only (no A2A/MCP). It is for greenfield sellers who own t
 
 ## Docker Setup UI (Dashboard)
 
-The existing setup UI at `/setup` currently allows sellers to configure plans and basic server settings. It must be updated to support the new `routes` concept alongside `plans`, and to make the distinction between the two concepts clear to sellers.
+The setup UI at `/setup` is a React SPA served from `ui/dist`. The layout is: a left-side configuration form with collapsible sections (60% width on large screens) + a sticky right-side output panel (40%) showing live previews of the agent card, MCP terminal walkthrough, and deployment scripts. The current form has 6 sections: Company, Pricing Plans, Token Issuance, Wallet & Network, Server & Storage, Refund Cron.
 
-### What the UI Must Express
+This spec requires three changes to the form and its backing API:
+1. Replace the "Pricing Plans" section with a combined **"Plans & Routes"** section
+2. Add a **"Gateway / Proxy"** section (conditionally required when routes are configured)
+3. Make the "Token Issuance" section conditionally required (only when plans are configured)
 
-The UI has two distinct configuration sections:
+All other sections (Company, Wallet & Network, Server & Storage, Refund Cron) and their fields are unchanged.
 
-**Plans (subscription tiers)**
-- Each plan has: Plan ID, Price (monthly), Description
-- After payment, Key0 issues a JWT. The seller's own backend decides what the JWT unlocks.
-- UI hint: "Clients pay once and get a token for ongoing access."
+---
 
-**Routes (per-request APIs)**
-- Each route has: Route ID, HTTP Method, Path, Price per call (leave blank for free), Description
-- Key0 auto-gates each route. No JWT issued. Clients pay per call.
-- UI hint: "Each API call is individually priced. Key0 proxies requests to your backend."
-- Requires the "Backend URL" field (proxyTo.baseUrl) to be filled in.
+### Section: Plans & Routes (replaces "Pricing Plans")
 
-**Gateway settings** (shown when any routes are configured)
-- Backend URL (`proxyTo.baseUrl`) — required
-- Internal secret (`proxyTo.proxySecret`) — optional but recommended; shown with explanation of how the backend should validate it
+This section contains two independent sub-editors side by side (or stacked on mobile): one for Plans, one for Routes. A seller may configure plans only, routes only, or both.
 
-### UX Principles
+**Plans sub-editor** (existing `PlanEditor`, unchanged field set)
 
-- **Two tabs or two clearly labelled sections** — "Plans" and "Routes" — so sellers immediately understand these are distinct concepts
-- **Contextual help inline**: for each section, one sentence explaining when to use it
-  - Plans: "Use when you want clients to subscribe for ongoing access (e.g. monthly API key)"
-  - Routes: "Use when you want to charge per API call and proxy requests to your backend"
-- **Backend URL field is prominent** when routes are configured — it's easy for sellers to miss that `proxyTo` is required
-- **Free route is zero-friction**: if Price is left blank, the route is free. No separate toggle needed.
-- **Live preview of the discovery response** — sellers can see exactly what agent clients will discover, updating as they type
+Each plan row:
+- **Plan ID** (required) — slug, e.g. `starter-monthly`
+- **Price in USDC** (required) — e.g. `5.00`
+- **Description** (optional)
 
-### Setup API Changes (`/api/setup`)
+Section hint: _"Clients pay once and receive a token for ongoing access. Your backend decides what each plan unlocks."_
 
-The `/api/setup/status` and `/api/setup/save` endpoints currently pass `plans` as a JSON array. They need to also pass `routes` and `proxyTo` config:
+Add/remove rows. Minimum 0 rows (routes-only sellers need no plans).
+
+**Routes sub-editor** (new `RouteEditor` component, modelled on `PlanEditor`)
+
+Each route row:
+- **Route ID** (required) — slug, e.g. `weather-query`
+- **Method** (required) — dropdown: `GET | POST | PUT | DELETE | PATCH`; default `GET`
+- **Path** (required) — Express-style param path, e.g. `/api/weather/:city`
+- **Price per call in USDC** (optional) — leave blank for free
+- **Description** (optional)
+
+Section hint: _"Each API call is individually gated. Paid routes require payment per call. Free routes proxy directly. Your backend receives every request."_
+
+Add/remove rows. Minimum 0 rows (plans-only sellers need no routes).
+
+**Validation for this section:**
+- At least one plan OR one route must exist (save button disabled otherwise)
+- Each plan row: `planId` and `unitAmount` both required
+- Each route row: `routeId`, `method`, and `path` all required; `unitAmount` optional
+- `path` must start with `/`
+- `routeId` and `planId` values must be unique within their respective lists (no duplicates)
+
+---
+
+### Section: Gateway / Proxy (new, conditionally shown)
+
+Shown only when at least one route is configured. Collapsed by default if no routes exist yet; auto-expands when the first route is added.
+
+Fields:
+- **Backend URL** (required when routes exist) — `PROXY_TO_BASE_URL`, e.g. `http://localhost:3001`. Hint: _"Key0 will proxy all route requests to this base URL."_
+- **Internal Secret** (optional, password field) — `KEY0_PROXY_SECRET`. Sent as `x-key0-internal-token` on every proxied request. Hint: _"Validate this header in your backend to ensure requests came through Key0."_ Masked in status response using same `••••••` pattern as other secrets.
+
+**Validation:**
+- If any route is configured → Backend URL is required; save button remains disabled without it
+- If no routes are configured → entire section hidden; Backend URL not required
+
+---
+
+### Section: Token Issuance (now conditionally required)
+
+Currently always required. Under the new design, it is **only required when plans are configured**.
+
+- If plans list is non-empty → Issue Token API and backend auth fields are required (unchanged behaviour)
+- If plans list is empty (routes-only seller) → entire Token Issuance section is hidden; `ISSUE_TOKEN_API` is not written to `.env.runtime`
+
+This eliminates the confusing situation where a routes-only seller must fill in a callback URL that will never be called.
+
+---
+
+### Validation Summary
+
+The overall save-button enabled condition becomes:
+
+```
+(plans.length > 0 || routes.length > 0)                         // at least one thing configured
+AND (plans.length === 0 || issueTokenApi.length > 0)            // token API required only with plans
+AND (routes.length === 0 || proxyToBaseUrl.length > 0)          // backend URL required only with routes
+AND walletAddress valid (0x + 42 chars)
+AND storage backend requirement met (redis/postgres URL or managed)
+AND all plan rows have planId + unitAmount
+AND all route rows have routeId + method + path
+AND no duplicate planIds
+AND no duplicate routeIds
+AND all paths start with /
+```
+
+---
+
+### Output Panel Changes
+
+**Experience tab — Agent Card subtab:** Update `generateAgentCard()` to include `routes` array in the discovery preview. Show route entries with `routeId`, method, path, and price (or "free"). The terminal walkthrough should demonstrate a route call via `/x402/access` in addition to the existing subscription plan flow.
+
+**Experience tab — MCP subtab:** Update `generateMcpTerminal()` to show `discover_api` (renamed from `discover_plans`) returning both plans and routes.
+
+**Deploy tab — .env subtab:** `generateEnv()` must write:
+- `ROUTES_B64` — base64 JSON of routes array (when routes are configured), matching `PLANS_B64` pattern
+- `PROXY_TO_BASE_URL` — when routes are configured
+- `KEY0_PROXY_SECRET` — when set
+- Omit `ISSUE_TOKEN_API` and `BACKEND_AUTH_STRATEGY` when plans list is empty
+
+**Deploy tab — docker-compose.yml and docker run subtabs:** No structural changes; the new env vars are injected automatically via `generateEnv()`.
+
+---
+
+### Setup API Changes
+
+**`GET /api/setup/status` — additions to `config` object in response:**
 
 ```typescript
-// GET /api/setup/status — add to response:
 {
-  routes: Route[];           // from ROUTES_B64 or ROUTES env var
-  proxyToBaseUrl: string;    // from PROXY_TO_BASE_URL env var
-  proxySecret: string;       // from KEY0_PROXY_SECRET env var (masked)
-}
-
-// POST /api/setup/save — add to body:
-{
-  routes: Route[];
-  proxyToBaseUrl: string;
-  proxySecret?: string;
+  // existing fields...
+  routes: Route[];            // parsed from ROUTES_B64 or ROUTES env var; [] if absent/invalid
+  proxyToBaseUrl: string;     // from PROXY_TO_BASE_URL env var; "" if absent
+  proxySecret: string;        // from KEY0_PROXY_SECRET env var; "••••••" if set, "" if absent
 }
 ```
 
-The Docker server reads `routes` from a `ROUTES_B64` env var (base64 JSON), matching the existing pattern for `PLANS_B64`.
+Error handling for `ROUTES_B64`: same as `PLANS_B64` — if present but invalid JSON, server logs a warning and exits with code 1.
+
+**`POST /api/setup` — additions to request body:**
+
+```typescript
+{
+  // existing fields...
+  routes: Route[];
+  proxyToBaseUrl: string;
+  proxySecret: string;        // empty string means "clear it"; "••••••" means "keep existing"
+}
+```
+
+**`POST /api/setup` — server-side validation additions:**
+- If `routes.length > 0` and `proxyToBaseUrl` is empty → return 400 `"proxyToBaseUrl is required when routes are configured"`
+- If `plans.length > 0` and `issueTokenApi` is empty → existing 400 behaviour (unchanged)
+- If both `plans` and `routes` are empty → return 400 `"At least one plan or route must be configured"`
+
+**`POST /api/setup` — `.env.runtime` write additions:**
+- Write `ROUTES_B64=<base64>` when routes is non-empty (same encoding as `PLANS_B64`)
+- Write `PROXY_TO_BASE_URL=<url>` when `proxyToBaseUrl` is non-empty
+- Write `KEY0_PROXY_SECRET=<secret>` when proxySecret is non-empty and not masked
+- Omit `ISSUE_TOKEN_API` when plans list is empty
+- Secret masking: `proxySecret` is filtered same as other secrets — if value contains `•`, skip write to preserve existing value
+
+---
+
+### Edge Cases
+
+| Scenario | Expected behaviour |
+|---|---|
+| Routes-only seller saves with no Backend URL | Save button disabled; inline error on Backend URL field |
+| Routes-only seller (no plans) — Token Issuance section hidden? | Yes — section hides; `issueTokenApi` not required |
+| Plans-only seller (no routes) — Token Issuance section hidden? | No — section stays visible and required; unchanged behaviour |
+| Seller adds first route | Gateway section auto-expands; Backend URL field highlighted |
+| Seller removes all routes | Gateway section collapses and hides; Backend URL no longer blocks save |
+| Seller removes all plans | Token Issuance section hides; `ISSUE_TOKEN_API` omitted from .env |
+| `ROUTES_B64` is invalid base64/JSON at startup | Server logs error, exits code 1 (same as `PLANS_B64`) |
+| `ROUTES_B64` is absent | `routes` defaults to `[]`; no error |
+| Duplicate `routeId` values | Inline validation error on the duplicate row; save blocked |
+| Route path without leading `/` | Inline validation error on the path field |
+| `proxySecret` not changed by user | Frontend sends `"••••••"`; server skips write, preserving existing value |
+| `proxySecret` cleared by user | Frontend sends `""`; server omits `KEY0_PROXY_SECRET` from .env |
+| Mixed plans + routes, only routes failing validation | Save blocked; only route section shows errors |
+| Server restarting after save | Existing poll-until-configured behaviour unchanged |
 
 ---
 

--- a/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
+++ b/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
@@ -178,8 +178,8 @@ All routes — paid and free — are also accessible via `POST /x402/access` and
 For free routes, `txHash` and `explorerUrl` are absent. For backend non-2xx responses via A2A: refund is initiated, and the backend error is surfaced inside `resource` (status + body from backend unchanged).
 
 **MCP tools:**
-- `discover_plans` → renamed to `discover_api` — returns both plans and routes
-- `request_access` → handles both `planId` (subscription) and `routeId` (route); exactly one required
+- `discover_plans` → renamed to `discover` — returns both plans and routes
+- `request_access` → renamed to `access` — handles both `planId` (subscription) and `routeId` (route); exactly one required
 
 ### Error Pass-Through Contract
 
@@ -192,7 +192,7 @@ In both cases, the backend status code and body are preserved. Key0 never replac
 
 ### Discovery Endpoint
 
-`GET /discovery` returns both plans and routes. The response is unwrapped (no `discoveryResponse` wrapper — this is a fix from the current branch):
+`GET /discover` returns both plans and routes. The response is unwrapped (no `discoveryResponse` wrapper — this is a fix from the current branch):
 
 ```json
 {
@@ -330,7 +330,7 @@ AND all paths start with /
 
 **Experience tab — Agent Card subtab:** Update `generateAgentCard()` to include `routes` array in the discovery preview. Show route entries with `routeId`, method, path, and price (or "free"). The terminal walkthrough should demonstrate a route call via `/x402/access` in addition to the existing subscription plan flow.
 
-**Experience tab — MCP subtab:** Update `generateMcpTerminal()` to show `discover_api` (renamed from `discover_plans`) returning both plans and routes.
+**Experience tab — MCP subtab:** Update `generateMcpTerminal()` to show `discover` (renamed from `discover_plans`) returning both plans and routes.
 
 **Deploy tab — .env subtab:** `generateEnv()` must write:
 - `ROUTES_B64` — base64 JSON of routes array (when routes are configured), matching `PLANS_B64` pattern
@@ -417,7 +417,8 @@ This is a **breaking change** to the `feat/pay-per-request` branch (not to `main
 | `Plan.routes` | Top-level `SellerConfig.routes` |
 | `SellerConfig.fetchResource` | `proxyTo` (custom logic moves to backend) |
 | `key0.payPerRequest(planId)` | `key0.payPerRequest(routeId)` (parameter rename) |
-| `discoveryResponse` wrapper on `GET /discovery` | Unwrapped response object |
+| `GET /discovery` endpoint | Renamed to `GET /discover` |
+| `discoveryResponse` wrapper on `GET /discover` | Unwrapped response object |
 
 The subscription flow (`Plan` → payment → JWT) is **unchanged**. Sellers using only subscription plans today are unaffected.
 
@@ -451,10 +452,10 @@ The subscription flow (`Plan` → payment → JWT) is **unchanged**. Sellers usi
 
 ### MCP Tools
 
-16. **`discover_api` tool:** Returns both plans and routes with correct schema; free routes have no `unitAmount`
-17. **`request_access` with routeId — paid:** Settles payment → `ResourceResponse`
-18. **`request_access` with routeId — free:** No payment → `ResourceResponse`
-19. **`request_access` with planId:** Subscription flow unchanged → `AccessGrant` JWT
+16. **`discover` tool:** Returns both plans and routes with correct schema; free routes have no `unitAmount`
+17. **`access` with routeId — paid:** Settles payment → `ResourceResponse`
+18. **`access` with routeId — free:** No payment → `ResourceResponse`
+19. **`access` with planId:** Subscription flow unchanged → `AccessGrant` JWT
 
 ### Subscription Plans (Regression)
 
@@ -471,12 +472,12 @@ The subscription flow (`Plan` → payment → JWT) is **unchanged**. Sellers usi
 ### Coexistence
 
 26. **Seller with both plans and routes:** Subscription clients and per-request clients coexist
-27. **Discovery returns both:** `GET /discovery` includes both `plans` and `routes` arrays, no wrapper
+27. **Discovery returns both:** `GET /discover` includes both `plans` and `routes` arrays, no wrapper
 
 ### Docker Setup UI
 
 28. **Routes persist across restart:** Routes saved via `/api/setup/save` are written to `ROUTES_B64` and survive container restart
-29. **Discovery reflects saved routes:** After saving routes via UI, `GET /discovery` returns them correctly
+29. **Discovery reflects saved routes:** After saving routes via UI, `GET /discover` returns them correctly
 30. **Free route in UI:** Route saved with blank price → discovery shows no `unitAmount` → transparent proxy requires no payment
 
 ---

--- a/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
+++ b/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
@@ -177,6 +177,12 @@ All routes — paid and free — are also accessible via `POST /x402/access` and
 
 For free routes, `txHash` and `explorerUrl` are absent. For backend non-2xx responses via A2A: refund is initiated, and the backend error is surfaced inside `resource` (status + body from backend unchanged).
 
+**A2A agent card skills:**
+- Skill `id: "discover-plans"`, `name: "Discover Plans"` → `id: "discover"`, `name: "Discover"`
+- Skill `id: "request-access"`, `name: "Request Access"` → `id: "access"`, `name: "Access"`
+- All skill descriptions and examples referencing `${baseUrl}/discovery` → `${baseUrl}/discover`
+- Per-request route skills: `id` prefix `ppr-<planId>-` → `ppr-<routeId>-` (reflects route/plan split)
+
 **MCP tools:**
 - `discover_plans` → renamed to `discover` — returns both plans and routes
 - `request_access` → renamed to `access` — handles both `planId` (subscription) and `routeId` (route); exactly one required
@@ -419,6 +425,10 @@ This is a **breaking change** to the `feat/pay-per-request` branch (not to `main
 | `key0.payPerRequest(planId)` | `key0.payPerRequest(routeId)` (parameter rename) |
 | `GET /discovery` endpoint | Renamed to `GET /discover` |
 | `discoveryResponse` wrapper on `GET /discover` | Unwrapped response object |
+| A2A skill `id: "discover-plans"` | Renamed to `id: "discover"` |
+| A2A skill `id: "request-access"` | Renamed to `id: "access"` |
+| MCP tool `discover_plans` | Renamed to `discover` |
+| MCP tool `request_access` | Renamed to `access` |
 
 The subscription flow (`Plan` → payment → JWT) is **unchanged**. Sellers using only subscription plans today are unaffected.
 

--- a/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
+++ b/docs/superpowers/specs/2026-03-19-pay-per-request-redesign.md
@@ -1,0 +1,390 @@
+# Pay-Per-Request Redesign Spec
+
+**Date:** 2026-03-19
+**Branch:** feat/pay-per-request
+**Status:** Draft
+
+---
+
+## Overview
+
+The current `feat/pay-per-request` branch introduces pay-per-request billing but with a config shape that conflates two separate concepts: subscription plans and priced API routes. This spec redesigns the config surface, adds transparent HTTP proxy support for brownfield sellers, and ensures all routes (paid and free) are accessible via HTTP, A2A, and MCP — with full discovery. It also updates the Docker setup UI (dashboard) to expose these concepts intuitively.
+
+### Goals
+
+- Routes and plans are separate top-level concepts in `SellerConfig`
+- Brownfield sellers can add Key0 in front of an existing API with minimal backend changes — existing API response shapes are preserved exactly (no wrapper)
+- Every route is accessible via HTTP (transparent proxy), A2A (`/x402/access`), and MCP
+- Discovery exposes the full API spec (routes and plans) so agent clients can find and call any endpoint
+- `fetchResourceCredentials` is only required when subscription plans exist
+- The Docker setup UI makes it intuitive to configure both routes and plans
+- No breaking changes to the subscription flow
+
+### Non-Goals
+
+- Per-route timeout configuration (future work)
+- HMAC-signed payment headers (future work)
+- Dynamic route discovery from backend OpenAPI specs
+- Dashboard authentication (existing security model unchanged — `/setup` is Docker-internal only)
+
+---
+
+## Config API Changes
+
+### `Plan` — Subscription-only
+
+Plans become purely subscription-focused. All PPR/proxy/free fields are removed.
+
+```typescript
+type Plan = {
+  planId: string;
+  unitAmount: string;       // required — subscription price
+  description?: string;
+};
+```
+
+**Removed from Plan:** `mode`, `free`, `proxyPath`, `proxyMethod`, `proxyQuery`, `routes`
+
+### `Route` — New type
+
+A `Route` is a priced (or free) API endpoint that Key0 exposes via transparent proxy, A2A, and MCP.
+
+```typescript
+type Route = {
+  routeId: string;                                           // stable identifier used in discovery + A2A/MCP calls
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  path: string;                                             // Express-style :param (e.g. "/api/weather/:city")
+  unitAmount?: string;                                      // omit for free routes
+  description?: string;
+};
+```
+
+A route with no `unitAmount` is free — no payment required, proxied directly.
+
+### `SellerConfig` — Updated
+
+`fetchResource` (the programmatic proxy callback from the current branch) is removed. `proxyTo` is the only proxy mechanism when using the gateway mode. Sellers who need custom routing logic should handle it in their backend behind the proxy.
+
+```typescript
+type SellerConfig = {
+  agentName: string;
+  walletAddress: `0x${string}`;
+  network: "mainnet" | "testnet";
+  basePath?: string;                                         // default "/agent"
+
+  plans?: Plan[];                                           // subscription tiers (optional)
+  routes?: Route[];                                         // per-request + free endpoints (optional)
+
+  fetchResourceCredentials?: FetchResourceCredentialsFn;   // required only when plans is non-empty
+  proxyTo?: ProxyToConfig;                                  // required when routes is non-empty
+
+  // ... existing optional fields (redis, rpcUrl, gasWalletPrivateKey, etc.)
+};
+```
+
+**Validation rules (enforced at startup):**
+- If `plans` is non-empty → `fetchResourceCredentials` is required
+- If `routes` is non-empty → `proxyTo` is required
+- If both are absent → warn and proceed (developer mode / health-check only)
+
+### `ProxyToConfig` — Unchanged
+
+```typescript
+type ProxyToConfig = {
+  baseUrl: string;
+  headers?: Record<string, string>;     // static headers added to every proxied request
+  proxySecret?: string;                 // injected as x-key0-internal-token header
+};
+```
+
+### `ResourceResponse` type — Updated
+
+`planId` becomes optional (only present for subscription flows); `routeId` is added for route flows.
+
+```typescript
+type ResourceResponse = {
+  type: "ResourceResponse";
+  challengeId: string;
+  requestId: string;
+  planId?: string;       // present for subscription access grants
+  routeId?: string;      // present for route-based calls
+  txHash?: `0x${string}`; // absent for free routes
+  explorerUrl?: string;   // absent for free routes
+  resource: {
+    status: number;
+    headers?: Record<string, string>;
+    body: unknown;
+  };
+};
+```
+
+---
+
+## Behavior
+
+### Transparent HTTP Proxy
+
+When `routes` is configured, Key0 auto-mounts each route at its declared `method` + `path` on the same server at startup. The seller registers no additional routes manually.
+
+The transparent proxy forwards the matched Express path (with parameters already substituted) to `proxyTo.baseUrl`. For example, a request to `GET /api/weather/london` matching route `GET /api/weather/:city` is forwarded to `{baseUrl}/api/weather/london` verbatim. Query parameters from the original request are forwarded unchanged.
+
+**Paid route flow:**
+1. Request arrives at e.g. `GET /api/weather/london`
+2. No `PAYMENT-SIGNATURE` header → respond `402 Payment Required` with requirements
+3. Valid `PAYMENT-SIGNATURE` → settle on-chain → proxy to `proxyTo.baseUrl + matched path` → return backend response body and headers **unchanged**
+4. Backend non-2xx → initiate refund → return backend error status + body **unchanged**
+
+**Free route flow:**
+1. Request arrives at e.g. `GET /health`
+2. Proxy directly to `proxyTo.baseUrl + matched path` → return backend response unchanged
+
+The backend response is **never wrapped** for transparent proxy routes. Status code, headers, and body pass through exactly as received from the backend.
+
+**Headers added to the upstream request (transparent proxy only):**
+- `x-key0-internal-token` — if `proxySecret` is set; use this in the backend to verify the request came through Key0
+- `x-key0-tx-hash`, `x-key0-route-id`, `x-key0-amount`, `x-key0-payer` — on paid routes only (informational; not tamper-proof, do not use for trust decisions)
+
+### A2A and MCP Access
+
+All routes — paid and free — are also accessible via `POST /x402/access` and MCP tools. The behavior is identical to the transparent proxy (same settlement, same backend call) but the response is wrapped in `ResourceResponse` for protocol compatibility.
+
+**A2A request shape for routes:**
+```json
+{
+  "routeId": "weather",
+  "resource": { "method": "GET", "path": "/api/weather/london" }
+}
+```
+
+`/x402/access` continues to accept `planId` for subscription flows unchanged. It now also accepts `routeId` for route flows. Exactly one of `planId` or `routeId` must be present.
+
+**A2A response for paid routes:**
+```json
+{
+  "type": "ResourceResponse",
+  "challengeId": "...",
+  "requestId": "...",
+  "routeId": "weather",
+  "txHash": "0x...",
+  "explorerUrl": "...",
+  "resource": {
+    "status": 200,
+    "headers": { "content-type": "application/json" },
+    "body": { "temp": 72 }
+  }
+}
+```
+
+For free routes, `txHash` and `explorerUrl` are absent. For backend non-2xx responses via A2A: refund is initiated, and the backend error is surfaced inside `resource` (status + body from backend unchanged).
+
+**MCP tools:**
+- `discover_plans` → renamed to `discover_api` — returns both plans and routes
+- `request_access` → handles both `planId` (subscription) and `routeId` (route); exactly one required
+
+### Error Pass-Through Contract
+
+| Access path | Backend 2xx | Backend non-2xx | Settlement after error |
+|---|---|---|---|
+| HTTP transparent proxy | Pass through unchanged | Pass through unchanged | Refund initiated |
+| A2A / MCP | Wrapped in `ResourceResponse.resource` | Wrapped in `ResourceResponse.resource` | Refund initiated |
+
+In both cases, the backend status code and body are preserved. Key0 never replaces a backend error with its own error shape (e.g. no 502 wrapping of backend 500s).
+
+### Discovery Endpoint
+
+`GET /discovery` returns both plans and routes. The response is unwrapped (no `discoveryResponse` wrapper — this is a fix from the current branch):
+
+```json
+{
+  "agentName": "Weather API",
+  "plans": [
+    { "planId": "premium", "unitAmount": "$5.00", "description": "Monthly access" }
+  ],
+  "routes": [
+    {
+      "routeId": "weather",
+      "method": "GET",
+      "path": "/api/weather/:city",
+      "unitAmount": "$0.01",
+      "description": "Get current weather for a city"
+    },
+    {
+      "routeId": "health",
+      "method": "GET",
+      "path": "/health"
+    }
+  ]
+}
+```
+
+Free routes have no `unitAmount` field. The gateway does not add a computed `free: true` field — absence of `unitAmount` indicates a free route.
+
+### Embedded Mode — API Rename
+
+Sellers using `key0.payPerRequest()` middleware directly on their Express/Hono/Fastify app continue to work. The parameter is renamed from `planId` to `routeId` (breaking change within the branch; not a main-branch change). The middleware resolves the `routeId` against `SellerConfig.routes`.
+
+```typescript
+app.get("/api/weather/:city", key0.payPerRequest("weather"), handler);
+// req.key0Payment contains payment metadata
+```
+
+This mode remains HTTP-only (no A2A/MCP). It is for greenfield sellers who own the app and prefer middleware-style gating. In this case, `proxyTo` is not needed.
+
+---
+
+## Docker Setup UI (Dashboard)
+
+The existing setup UI at `/setup` currently allows sellers to configure plans and basic server settings. It must be updated to support the new `routes` concept alongside `plans`, and to make the distinction between the two concepts clear to sellers.
+
+### What the UI Must Express
+
+The UI has two distinct configuration sections:
+
+**Plans (subscription tiers)**
+- Each plan has: Plan ID, Price (monthly), Description
+- After payment, Key0 issues a JWT. The seller's own backend decides what the JWT unlocks.
+- UI hint: "Clients pay once and get a token for ongoing access."
+
+**Routes (per-request APIs)**
+- Each route has: Route ID, HTTP Method, Path, Price per call (leave blank for free), Description
+- Key0 auto-gates each route. No JWT issued. Clients pay per call.
+- UI hint: "Each API call is individually priced. Key0 proxies requests to your backend."
+- Requires the "Backend URL" field (proxyTo.baseUrl) to be filled in.
+
+**Gateway settings** (shown when any routes are configured)
+- Backend URL (`proxyTo.baseUrl`) — required
+- Internal secret (`proxyTo.proxySecret`) — optional but recommended; shown with explanation of how the backend should validate it
+
+### UX Principles
+
+- **Two tabs or two clearly labelled sections** — "Plans" and "Routes" — so sellers immediately understand these are distinct concepts
+- **Contextual help inline**: for each section, one sentence explaining when to use it
+  - Plans: "Use when you want clients to subscribe for ongoing access (e.g. monthly API key)"
+  - Routes: "Use when you want to charge per API call and proxy requests to your backend"
+- **Backend URL field is prominent** when routes are configured — it's easy for sellers to miss that `proxyTo` is required
+- **Free route is zero-friction**: if Price is left blank, the route is free. No separate toggle needed.
+- **Live preview of the discovery response** — sellers can see exactly what agent clients will discover, updating as they type
+
+### Setup API Changes (`/api/setup`)
+
+The `/api/setup/status` and `/api/setup/save` endpoints currently pass `plans` as a JSON array. They need to also pass `routes` and `proxyTo` config:
+
+```typescript
+// GET /api/setup/status — add to response:
+{
+  routes: Route[];           // from ROUTES_B64 or ROUTES env var
+  proxyToBaseUrl: string;    // from PROXY_TO_BASE_URL env var
+  proxySecret: string;       // from KEY0_PROXY_SECRET env var (masked)
+}
+
+// POST /api/setup/save — add to body:
+{
+  routes: Route[];
+  proxyToBaseUrl: string;
+  proxySecret?: string;
+}
+```
+
+The Docker server reads `routes` from a `ROUTES_B64` env var (base64 JSON), matching the existing pattern for `PLANS_B64`.
+
+---
+
+## Backward Compatibility
+
+This is a **breaking change** to the `feat/pay-per-request` branch (not to `main`). The following are removed:
+
+| Removed | Replacement |
+|---|---|
+| `Plan.mode` | Separate `routes` array |
+| `Plan.free` | Route with no `unitAmount` |
+| `Plan.proxyPath` | `Route.path` |
+| `Plan.proxyMethod` | `Route.method` |
+| `Plan.proxyQuery` | Seller backend responsibility |
+| `Plan.routes` | Top-level `SellerConfig.routes` |
+| `SellerConfig.fetchResource` | `proxyTo` (custom logic moves to backend) |
+| `key0.payPerRequest(planId)` | `key0.payPerRequest(routeId)` (parameter rename) |
+| `discoveryResponse` wrapper on `GET /discovery` | Unwrapped response object |
+
+The subscription flow (`Plan` → payment → JWT) is **unchanged**. Sellers using only subscription plans today are unaffected.
+
+---
+
+## E2E Test Cases
+
+### Transparent Proxy — Paid Route
+
+1. **Happy path:** Client sends `GET /api/weather/london` with valid `PAYMENT-SIGNATURE` → backend receives request with `x-key0-tx-hash` and `x-key0-internal-token` headers → client receives raw backend response unchanged (status, headers, body)
+2. **No payment header:** `GET /api/weather/london` without signature → `402 Payment Required` with payment requirements
+3. **Invalid signature:** Invalid `PAYMENT-SIGNATURE` → `402` with error detail
+4. **Double spend:** Reuse same `txHash` → `402` rejected
+5. **Backend non-2xx:** Backend returns `500` with error body → refund initiated → client receives `500` with exact backend body unchanged
+6. **Backend timeout:** Backend takes >30s → refund initiated → client receives `504`
+7. **Path parameters forwarded correctly:** Route `GET /api/weather/:city`, request `GET /api/weather/london` → backend receives `GET /api/weather/london` (not `/api/weather/:city`)
+8. **Query parameters forwarded:** `GET /api/weather/london?units=metric` → backend receives `?units=metric` unchanged
+
+### Transparent Proxy — Free Route
+
+9. **Happy path:** Client sends `GET /health` with no headers → proxied directly → raw backend response returned
+10. **With spurious payment header:** Header is ignored, route still proxies freely
+
+### A2A — Routes
+
+11. **Paid route via A2A:** `POST /x402/access` with `routeId` + `PAYMENT-SIGNATURE` → `ResourceResponse` with `resource.body` matching backend response
+12. **Free route via A2A:** `POST /x402/access` with `routeId` for free route, no payment needed → `ResourceResponse` with no `txHash`
+13. **Unknown routeId:** → `404` error response
+14. **Backend non-2xx via A2A:** → refund initiated → `ResourceResponse` with `resource.status` = backend status, `resource.body` = backend body unchanged
+15. **`planId` and `routeId` both present:** → `400` error (ambiguous request)
+
+### MCP Tools
+
+16. **`discover_api` tool:** Returns both plans and routes with correct schema; free routes have no `unitAmount`
+17. **`request_access` with routeId — paid:** Settles payment → `ResourceResponse`
+18. **`request_access` with routeId — free:** No payment → `ResourceResponse`
+19. **`request_access` with planId:** Subscription flow unchanged → `AccessGrant` JWT
+
+### Subscription Plans (Regression)
+
+20. **Subscription happy path:** `POST /x402/access` with `planId` → `AccessGrant` JWT (unchanged)
+21. **`validateAccessToken` middleware:** JWT from subscription plan still accepted on protected routes
+
+### Config Validation
+
+22. **routes without proxyTo:** Startup throws clear error message
+23. **plans without fetchResourceCredentials:** Startup throws clear error message
+24. **Route with no unitAmount:** Treated as free, `402` never returned
+25. **Both plans and routes configured:** Both work independently on the same server
+
+### Coexistence
+
+26. **Seller with both plans and routes:** Subscription clients and per-request clients coexist
+27. **Discovery returns both:** `GET /discovery` includes both `plans` and `routes` arrays, no wrapper
+
+### Docker Setup UI
+
+28. **Routes persist across restart:** Routes saved via `/api/setup/save` are written to `ROUTES_B64` and survive container restart
+29. **Discovery reflects saved routes:** After saving routes via UI, `GET /discovery` returns them correctly
+30. **Free route in UI:** Route saved with blank price → discovery shows no `unitAmount` → transparent proxy requires no payment
+
+---
+
+## Documentation Updates
+
+### README
+
+- Replace "plans" section with two sections: **Subscription Plans** and **Per-Request Routes**
+- Add quickstart snippet showing `routes` config alongside `proxyTo` for the gateway pattern
+- Add comparison table: subscription vs per-request vs free route
+- Update Docker quickstart to show the setup UI's two-section layout
+
+### Mintlify
+
+- **`introduction/two-modes.mdx`** — Update to describe embedded vs gateway; clarify gateway supports HTTP + A2A + MCP for all routes
+- **`introduction/core-concepts.mdx`** — Add `Route` as a first-class concept alongside `Plan`; explain the distinction
+- **`sdk-reference/seller-config.mdx`** — Add `routes` field, update `plans` to subscription-only, mark all removed fields with migration notes
+- **`api-reference/data-models.mdx`** — Add `Route` type; update `Plan` type; update `ResourceResponse` with optional `routeId`/`txHash`; fix discovery response shape (remove wrapper)
+- **`examples/ppr-embedded.mdx`** — Update `planId` → `routeId` in `payPerRequest()` call
+- **`examples/ppr-standalone.mdx`** — Full rewrite: show top-level `routes` array, transparent proxy behavior, A2A + MCP access, no response wrapper
+- **New: `guides/routes-vs-plans.mdx`** — When to use routes vs plans; how sellers use `validateAccessToken` to control subscription access; free route pattern
+- **`architecture/payment-flow.mdx`** — Add transparent proxy path alongside the existing A2A/subscription flows
+- **`deployment/environment-variables.mdx`** — Add `ROUTES_B64`, update `PLANS_B64` notes
+- **`deployment/docker.mdx`** — Update setup UI walkthrough to show Plans + Routes tabs


### PR DESCRIPTION
Closes #63

## What's in this PR

Design-only — no implementation code yet. Two documents:

- `docs/mpp-compatibility.md` — MPP protocol overview and how it maps to Key0's current x402 architecture
- `docs/superpowers/specs/2026-03-19-mpp-native-integration-design.md` — Full design spec for the native MPP migration

## Design decisions

| Decision | Choice |
|---|---|
| Integration depth | Full native MPP — not a translation shim |
| Seller config | `paymentMethods` required, explicit — no defaults |
| BaseUsdcAdapter | Wraps existing viem verification unchanged — only HTTP envelope changes |
| Stripe/Lightning | Architecture defined, implementation deferred (Stripe requires MPP SPT spec, not clientSecret) |
| `base-usdc` method | Custom MPP method — Key0 to publish spec + contribute mppx client handler |
| `ISeenTxStore` key | Broadened from `0x${string}` → `string` for non-USDC proof references |
| Challenge ID (HMAC) | Engine's responsibility — HMAC over (realm, method, intent, sha256(request), expires) |
| Receipt assembly | Engine assembles full receipt; adapter provides reference field only |
| Method assertion | Stored record is ground truth — prevents cheap-method substitution attacks |

## Review focus

- Does the `IPaymentAdapter` interface design feel right?
- Is the `ChallengeRecord` schema change (`method` + `methodData`) the right approach?
- Any concerns with the `ISeenTxStore` key type change?
- Are all files in the files-affected table accounted for?

## Not yet in this PR

Implementation will follow in separate PRs once the design is approved:
1. Types + `BaseUsdcAdapter`
2. Challenge engine (multi-adapter, MPP credential routing)
3. HTTP integrations (Express, Hono, Fastify)
4. MCP integration
5. Factory + seller config API