### PR TITLE
docs(readme): plug critical gaps for first-time developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="docs/logo.png" alt="Key0" width="260" />
+<img src="https://raw.githubusercontent.com/key0ai/key0/main/docs/logo.png" alt="Key0" width="260" />
 
 [![npm version](https://img.shields.io/npm/v/@key0ai/key0)](https://www.npmjs.com/package/@key0ai/key0)
 [![Docker](https://img.shields.io/docker/v/key0ai/key0?label=docker)](https://hub.docker.com/r/key0ai/key0)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/key0ai/key0)](./LICENSE)
 [![Docs](https://img.shields.io/badge/docs-key0.ai-blue)](https://docs.key0.ai/introduction/overview)
 
-key0 is an open-source commerce layer for AI agents and APIs. It lets agents discover pricing, pay in USDC on Base, and access protected services through HTTP x402, A2A, and MCP. It also generates `llms.txt`, `skills.md`, and related agent-facing surfaces to make it easier for agents to discover and interact with your offerings.
+key0 is the commercial gateway for your AI agents and APIs. Let AI agents discover, pay for, and access your APIs autonomously — no human in the loop. It handles payments in USDC on Base via HTTP x402, A2A, and MCP, and generates `llms.txt`, `skills.md`, and related agent-facing surfaces so agents can find and interact with your service out of the box.
 
 For integration, deployment, protocol, and API reference docs, see [docs.key0.ai](https://docs.key0.ai/introduction/overview).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/key0ai/key0)](./LICENSE)
 [![Docs](https://img.shields.io/badge/docs-key0.ai-blue)](https://docs.key0.ai/introduction/overview)
 
-key0 is the commercial gateway for your AI agents and APIs. Let AI agents discover, pay for, and access your APIs autonomously — no human in the loop. It handles payments in USDC on Base via HTTP x402, A2A, and MCP, and generates `llms.txt`, `skills.md`, and related agent-facing surfaces so agents can find and interact with your service out of the box.
+key0 is the open-source commercial gateway for your AI agents and APIs. Let AI agents discover, pay for, and access your APIs autonomously — no human in the loop. It handles payments in USDC on Base via HTTP x402, A2A, and MCP, and generates `llms.txt`, `skills.md`, and related agent-facing surfaces so agents can find and interact with your service out of the box.
 
 For integration, deployment, protocol, and API reference docs, see [docs.key0.ai](https://docs.key0.ai/introduction/overview).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ key0 is an open-source commerce layer for AI agents and APIs. It lets agents dis
 
 This README is intentionally short. Detailed integration, deployment, protocol, and API reference docs live in Mintlify at [docs.key0.ai](https://docs.key0.ai/introduction/overview).
 
-[Docs](https://docs.key0.ai/introduction/overview) · [Embedded Quickstart](https://docs.key0.ai/quickstart/embedded) · [Standalone Quickstart](https://docs.key0.ai/quickstart/standalone) · [Examples](#examples)
+[Docs](https://docs.key0.ai/introduction/overview) · [Standalone Quickstart](https://docs.key0.ai/quickstart/standalone) · [Embedded Quickstart](https://docs.key0.ai/quickstart/embedded) · [Examples](#examples)
 
 ## Why key0
 
@@ -21,14 +21,16 @@ This README is intentionally short. Detailed integration, deployment, protocol, 
 
 ## Choose a Mode
 
-| | Embedded SDK | Standalone Docker |
+> **Recommended for most teams:** Start with **Standalone Docker**. It is the fastest way to expose a paid agent-facing gateway without changing your application code.
+
+| | Standalone Docker | Embedded SDK |
 |---|---|---|
-| Best for | Existing apps that want full control in code | Teams that want a gateway with minimal app changes |
-| Install | `bun add @key0ai/key0` | `docker compose -f docker/docker-compose.yml --profile full up` |
-| Config | `SellerConfig` in TypeScript | Setup UI or environment variables |
-| Subscription flow | `fetchResourceCredentials` callback returns the credential | `ISSUE_TOKEN_API` returns the credential |
-| Per-request flow | Route-level middleware inside your app | Proxy mode through `PROXY_TO_BASE_URL` |
-| Docs | [Embedded](https://docs.key0.ai/quickstart/embedded) | [Standalone](https://docs.key0.ai/quickstart/standalone) |
+| Best for | Teams that want a gateway with minimal app changes | Existing apps that want full control in code |
+| Install | `docker compose -f docker/docker-compose.yml --profile full up` | `bun add @key0ai/key0` |
+| Config | Setup UI or environment variables | `SellerConfig` in TypeScript |
+| Subscription flow | `ISSUE_TOKEN_API` returns the credential | `fetchResourceCredentials` callback returns the credential |
+| Per-request flow | Proxy mode through `PROXY_TO_BASE_URL` | Route-level middleware inside your app |
+| Docs | [Standalone](https://docs.key0.ai/quickstart/standalone) | [Embedded](https://docs.key0.ai/quickstart/embedded) |
 
 For a full comparison, see [Two Modes](https://docs.key0.ai/introduction/two-modes).
 
@@ -36,7 +38,23 @@ For a full comparison, see [Two Modes](https://docs.key0.ai/introduction/two-mod
 
 Use `network: "testnet"` for local development and switch to `mainnet` only when you are ready to accept real payments.
 
-### Embedded
+### Standalone Docker
+
+```bash
+docker compose -f docker/docker-compose.yml --profile full up
+# Open http://localhost:3000
+```
+
+Standalone mode exposes the payment endpoints and generates the buyer onboarding bundle from your config, including `GET /discover`, `POST /x402/access`, optional `/.well-known/agent.json`, optional `/.well-known/mcp.json`, `/llms.txt`, and `/skills.md`.
+
+Continue with:
+
+- [Quickstart: Standalone](https://docs.key0.ai/quickstart/standalone)
+- [Docker deployment](https://docs.key0.ai/deployment/docker)
+- [Environment variables](https://docs.key0.ai/deployment/environment-variables)
+- [Refund architecture](https://docs.key0.ai/architecture/refunds)
+
+### Embedded SDK
 
 ```bash
 bun add @key0ai/key0 ioredis
@@ -88,22 +106,6 @@ Continue with:
 - [Hono integration](https://docs.key0.ai/integrations/hono)
 - [Fastify integration](https://docs.key0.ai/integrations/fastify)
 - [SellerConfig reference](https://docs.key0.ai/sdk-reference/seller-config)
-
-### Standalone
-
-```bash
-docker compose -f docker/docker-compose.yml --profile full up
-# Open http://localhost:3000
-```
-
-Standalone mode exposes the payment endpoints and generates the buyer onboarding bundle from your config, including `GET /discover`, `POST /x402/access`, optional `/.well-known/agent.json`, optional `/.well-known/mcp.json`, `/llms.txt`, and `/skills.md`.
-
-Continue with:
-
-- [Quickstart: Standalone](https://docs.key0.ai/quickstart/standalone)
-- [Docker deployment](https://docs.key0.ai/deployment/docker)
-- [Environment variables](https://docs.key0.ai/deployment/environment-variables)
-- [Refund architecture](https://docs.key0.ai/architecture/refunds)
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ bun run build
 
 E2E setup and wallet funding notes live in [`e2e/README.md`](./e2e/README.md).
 
+## Networks
+
+| Network | Chain | Chain ID | USDC Contract |
+|---|---|---|---|
+| `testnet` | Base Sepolia | 84532 | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| `mainnet` | Base | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
 ## Repository Docs
 
 - [`SPEC.md`](./SPEC.md)

--- a/README.md
+++ b/README.md
@@ -1,1100 +1,165 @@
-<img src="docs/logo.png" alt="key0" width="260" />
+<img src="docs/logo.png" alt="Key0" width="260" />
 
 [![npm version](https://img.shields.io/npm/v/@key0ai/key0)](https://www.npmjs.com/package/@key0ai/key0)
 [![Docker](https://img.shields.io/docker/v/key0ai/key0?label=docker)](https://hub.docker.com/r/key0ai/key0)
 [![License](https://img.shields.io/github/license/key0ai/key0)](./LICENSE)
 [![Docs](https://img.shields.io/badge/docs-key0.ai-blue)](https://docs.key0.ai/introduction/overview)
 
-key0 is the commercial gateway for your AI agents and APIs.
-Let AI agents discover, pay for, and access your APIs autonomously - no human in the loop.
+key0 is an open-source commerce layer for AI agents and APIs. It lets agents discover pricing, pay in USDC on Base, and access protected services through HTTP x402, A2A, and MCP.
 
-[Docs](https://docs.key0.ai/introduction/overview) · [Quick Start](#quick-start) · [Book a Demo](https://key0.ai/book-a-demo)
+This README is intentionally short. Detailed integration, deployment, protocol, and API reference docs live in Mintlify at [docs.key0.ai](https://docs.key0.ai/introduction/overview).
 
----
+[Docs](https://docs.key0.ai/introduction/overview) · [Embedded Quickstart](https://docs.key0.ai/quickstart/embedded) · [Standalone Quickstart](https://docs.key0.ai/quickstart/standalone) · [Examples](#examples)
 
-- **Two pricing models** - subscription plans (JWT) and per-request routes (transparent proxy)
-- **Open-source & self-hostable** - every part of the commerce flow is auditable
-- **Automatic refunds** - if anything goes wrong on-chain, key0 handles it
+## Why key0
 
-**Agent environments:** Claude Code, OpenClaw, Cursor, and more
-**Protocols:** HTTP x402, MCP, A2A
-**Payments:** Base (USDC) · Visa, Mastercard, UPI coming soon
+- Sell subscription plans or per-request routes to agents.
+- Run as embedded middleware or as a standalone Docker gateway.
+- Keep your existing API and credential model.
+- Support agent-native discovery through x402, A2A, and MCP.
+- Refund automatically when payment succeeds but delivery fails.
 
----
+## Choose a Mode
 
-## What is key0
+| | Embedded SDK | Standalone Docker |
+|---|---|---|
+| Best for | Existing apps that want full control in code | Teams that want a gateway with minimal app changes |
+| Install | `bun add @key0ai/key0` | `docker compose -f docker/docker-compose.yml --profile full up` |
+| Config | `SellerConfig` in TypeScript | Setup UI or environment variables |
+| Subscription flow | `fetchResourceCredentials` callback returns the credential | `ISSUE_TOKEN_API` returns the credential |
+| Per-request flow | Route-level middleware inside your app | Proxy mode through `PROXY_TO_BASE_URL` |
+| Docs | [Embedded](https://docs.key0.ai/quickstart/embedded) | [Standalone](https://docs.key0.ai/quickstart/standalone) |
 
-key0 is an open-source commerce layer for API sellers and agent builders.
-Sellers add key0 to any existing API - via Docker or SDK - to make it
-discoverable and purchasable by AI agents. Agents pay with USDC on Base;
-key0 handles verification, credential issuance, and automatic refunds if
-anything fails.
-
----
+For a full comparison, see [Two Modes](https://docs.key0.ai/introduction/two-modes).
 
 ## Quick Start
 
-| | [Standalone (Docker)](#standalone-mode) | [Embedded (SDK)](#embedded-mode) |
-|---|---|---|
-| **Setup** | `docker compose up` → browser Setup UI | `bun add @key0ai/key0` |
-| **Config** | Setup UI or environment variables | TypeScript config |
-| **Token issuance** | Delegated to your `ISSUE_TOKEN_API` | Your `fetchResourceCredentials` callback |
-| **Best for** | Quick deploy, no code changes | Full control, existing app |
+Use `network: "testnet"` for local development and switch to `mainnet` only when you are ready to accept real payments.
 
-### Standalone - 30 seconds
+### Embedded
 
 ```bash
-docker compose -f docker/docker-compose.yml --profile full up
-# Open http://localhost:3000 → configure via browser
+bun add @key0ai/key0 ioredis
 ```
 
-Standalone auto-hosts the buyer onboarding bundle from your config:
-`GET /discover`, `POST /x402/access`, optional `/.well-known/agent.json`,
-optional `/.well-known/mcp.json`, plus generated `/llms.txt` and `/skills.md`.
-To distribute a CLI binary to your users: run `buildCli()` from the SDK and upload the output to your preferred host (see [Agent CLI](#agent-cli)).
-
-### Embedded - Subscription Plans
-
-One-time payment, JWT issued, client calls your API directly with `Bearer` token.
-
-```bash
-bun add @key0ai/key0
-```
-
-```typescript
-import { key0Router, validateAccessToken } from "@key0ai/key0/express";
-
-app.use(key0Router({
-  config: {
-    walletAddress: "0xYour...",
-    network: "testnet",
-    plans: [{ planId: "basic", unitAmount: "$5.00", description: "100 API calls" }],
-    fetchResourceCredentials: async (params) => tokenIssuer.sign(params),
-  },
-  adapter, store, seenTxStore,
-}));
-app.use("/api", validateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
-```
-
-### Embedded - Per-Request Routes
-
-Per-call payment, key0 proxies to your backend via `proxyTo`, no JWT issued.
-
-```typescript
-import { key0Router } from "@key0ai/key0/express";
-
-app.use(key0Router({
-  config: {
-    walletAddress: "0xYour...",
-    network: "testnet",
-    routes: [
-      { routeId: "weather", method: "GET", path: "/api/weather/:city", unitAmount: "$0.01" },
-      { routeId: "health", method: "GET", path: "/health" }, // free
-    ],
-    proxyTo: { baseUrl: "http://your-backend.com", proxySecret: process.env.KEY0_PROXY_SECRET },
-  },
-  adapter, store, seenTxStore,
-}));
-```
-
-### Comparison
-
-| | Subscription Plan | Per-Request Route | Free Route |
-|---|---|---|---|
-| **Config** | `plans: [{ planId, unitAmount }]` | `routes: [{ routeId, method, path, unitAmount }]` | `routes: [{ routeId, method, path }]` (no `unitAmount`) |
-| **Payment** | One-time | Every call | None |
-| **Credential** | JWT via `fetchResourceCredentials` | None — transparent proxy | None — transparent proxy |
-| **Traffic flow** | Client calls your API directly | key0 proxies via `proxyTo` | key0 proxies via `proxyTo` |
-| **Discovery** | `GET /discover` → `plans[]` | `GET /discover` → `routes[]` | `GET /discover` → `routes[]` |
-
-`adapter`, `store`, and `seenTxStore` are constructed in the [Embedded Mode](#embedded-mode) section.
-
----
-
-## How It Works
-
-key0 sits between your server and any agent client. It handles the commerce
-handshake (discovery, challenge, on-chain verification, credential issuance)
-then gets out of the way. Your protected routes receive normal Bearer token
-requests.
-
-Two flows are supported. Both follow the same `PENDING → PAID → DELIVERED`
-lifecycle and are eligible for automatic refunds.
-
-### A2A Flow (Agent-to-Agent)
-
-```
-Client Agent          key0                    Seller Server
-     │  1. GET /.well-known/agent.json             │
-     │ ──────────────────▶│                         │
-     │ ◀── agent card + pricing                    │
-     │                   │                         │
-     │  2. AccessRequest │                         │
-     │ ──────────────────▶│                         │
-     │ ◀── X402Challenge  │                         │
-     │                   │                         │
-     │  3. Pay USDC on Base (on-chain)             │
-     │                   │                         │
-     │  4. PaymentProof  │                         │
-     │ ──────────────────▶│                         │
-     │                   │── verify on-chain        │
-     │                   │── fetchResourceCredentials ──▶│
-     │                   │◀── token                │
-     │ ◀── AccessGrant   │                         │
-     │                   │                         │
-     │  5. Bearer <JWT>  │                         │
-     │ ──────────────────────────────────────────▶│
-     │ ◀── protected content                       │
-```
-
-### HTTP x402 Flow (Gas Wallet / Facilitator)
-
-```
-Client                key0                    Seller Server
-     │  1. GET /discover  │                         │
-     │ ──────────────────▶│                         │
-     │ ◀── plan catalog   │                         │
-     │                   │                         │
-     │  2. POST /x402/access { planId }            │
-     │ ──────────────────▶│                         │
-     │ ◀── HTTP 402       │                         │
-     │                   │                         │
-     │  3. POST + PAYMENT-SIGNATURE                │
-     │ ──────────────────▶│                         │
-     │                   │── settle on-chain        │
-     │                   │── fetchResourceCredentials ──▶│
-     │ ◀── AccessGrant   │                         │
-     │                   │                         │
-     │  4. Bearer <JWT>  │                         │
-     │ ──────────────────────────────────────────▶│
-     │ ◀── protected content                       │
-```
-
-### Per-Request Routes (Transparent Proxy)
-
-For per-request `routes`, no JWT is issued. key0 settles the payment and transparently proxies the request to your backend via `proxyTo`:
-
-```
-Client                key0                    Backend
-     │  POST /x402/access { routeId }              │
-     │ ──────────────────▶│                         │
-     │ ◀── HTTP 402       │                         │
-     │                   │                         │
-     │  POST + PAYMENT-SIGNATURE                   │
-     │ ──────────────────▶│                         │
-     │                   │── settle on-chain        │
-     │                   │── proxy request ────────▶│
-     │                   │◀── backend response      │
-     │ ◀── ResourceResponse (backend data, no token)│
-```
-
-All paths share the same `PENDING → PAID → DELIVERED` lifecycle with automatic refunds if the backend call fails after a successful payment.
-
----
-
-## Standalone Mode
-
-Run key0 as a Docker container alongside your existing backend. No code changes required.
-
-**Subscription plans** — key0 calls your `ISSUE_TOKEN_API` and returns a JWT:
-
-```
-┌──────────────┐     ┌──────────────────────┐     ┌──────────────────┐
-│ Client Agent │     │    key0 (Docker)      │     │  Your Backend    │
-│              │────▶│  payment handshake    │     │                  │
-│              │◀────│  agent card + pricing │     │                  │
-│              │     │                       │     │                  │
-│              │     │  verify on-chain      │     │                  │
-│              │     │  POST /issue-token ───│────▶│  issue-token     │
-│              │◀────│  AccessGrant          │◀────│  {token, ...}    │
-└──────────────┘     └──────────────────────┘     └──────────────────┘
-```
-
-**Per-request routes** (set `PROXY_TO_BASE_URL`) — key0 proxies to your backend and returns the response directly:
-
-```
-┌──────────────┐     ┌──────────────────────┐     ┌──────────────────┐
-│ Client Agent │     │    key0 (Docker)      │     │  Your Backend    │
-│              │────▶│  POST /x402/access    │     │                  │
-│              │◀────│  { routeId }          │     │                  │
-│              │     │  402 + requirements   │     │                  │
-│              │     │                       │     │                  │
-│              │     │  verify on-chain      │     │                  │
-│              │     │  proxy request ───────│────▶│  GET /api/...    │
-│              │◀────│  ResourceResponse     │◀────│  200 {data}      │
-└──────────────┘     └──────────────────────┘     └──────────────────┘
-```
-
-### Setup
-
-There are two ways to configure Standalone mode:
-
-#### Option A: Setup UI (zero-config start)
-
-Just start the container with no environment variables - key0 boots into **Setup Mode** and serves a browser-based configuration wizard:
-
-```bash
-docker compose -f docker/docker-compose.yml --profile full up
-# Open http://localhost:3000 → redirects to /setup
-# Managed infra (Redis, Postgres) is auto-detected at startup - no extra env vars needed.
-```
-
-Docker Compose profiles control which infrastructure services are bundled:
-
-| Profile | What starts |
-|---|---|
-| *(none)* | key0 only - bring your own Redis + Postgres via env vars |
-| `--profile redis` | key0 + managed Redis |
-| `--profile postgres` | key0 + managed Postgres (still needs Redis externally) |
-| `--profile full` | key0 + managed Redis + managed Postgres (batteries included) |
-
-The Setup UI lets you configure everything visually: wallet address, network, pricing plans, token issuance API, settlement, and refund settings. When you submit, the server writes the config and restarts automatically.
-
-Configuration is persisted in a Docker volume (`key0-config`), so it survives `docker compose down` / `up` cycles.
-
-The Setup UI also works as a **standalone config generator** - open it outside Docker to generate `.env` files, `docker run` commands, or `docker-compose.yml` files you can copy. See [`docs/setup-ui.md`](./docs/setup-ui.md) for architecture details.
-
-### Automatic Buyer Onboarding Bundle
-
-By default, standalone key0 generates and hosts these buyer-facing endpoints from your seller config:
-
-| Endpoint | Default | Control |
-|---|---|---|
-| `GET /discover` | on | always on |
-| `POST /x402/access` | on | always on |
-| `GET /.well-known/agent.json` | on | `A2A_ENABLED=false` disables it |
-| `GET /.well-known/mcp.json` + `POST /mcp` | off | `MCP_ENABLED=true` enables them |
-| `GET /llms.txt` | on | `LLMS_ENABLED=false` disables it |
-| `GET /skills.md` | on | `SKILLS_MD_ENABLED=false` disables it |
-
-To distribute a CLI binary to your users: run `buildCli()` from the SDK and upload the output to your preferred host (e.g. GitHub Releases, S3, a CDN). See [Agent CLI](#agent-cli) for details.
-
-#### Option B: Environment variables
-
-Set the two required variables and start immediately:
-
-| Variable | Description |
-|---|---|
-| `KEY0_WALLET_ADDRESS` | USDC-receiving wallet (`0x...`) |
-| `ISSUE_TOKEN_API` | URL that key0 POSTs to after payment is verified |
-
-```bash
-docker run \
-  -e KEY0_WALLET_ADDRESS=0xYourWallet \
-  -e ISSUE_TOKEN_API=https://api.example.com/issue-token \
-  -p 3000:3000 \
-  key0ai/key0:latest
-```
-
-### With Docker Compose + Redis
-
-```bash
-cp docker/.env.example docker/.env
-# Edit docker/.env: set KEY0_WALLET_ADDRESS and ISSUE_TOKEN_API
-docker compose -f docker/docker-compose.yml --profile redis up
-```
-
-> Even with env vars pre-configured, the Setup UI is always available at `/setup` for reconfiguration.
-
-### Docker Image
-
-Published to Docker Hub on every release: [`key0ai/key0`](https://hub.docker.com/r/key0ai/key0)
-
-| Tag | When |
-|---|---|
-| `latest` | Latest stable release |
-| `1.2.3` / `1.2` / `1` | Specific version pinning |
-| `canary` | Latest `main` branch build |
-
-Build from source: `docker build -t key0ai/key0 .`
-
-### Environment Variables
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `KEY0_WALLET_ADDRESS` | ✅ | - | Your wallet address (`0x…`) that receives USDC payments from agents |
-| `ISSUE_TOKEN_API` | ✅ | - | Your endpoint that key0 POSTs to after payment is verified to issue access tokens |
-| `KEY0_NETWORK` | | `testnet` | Blockchain network - `mainnet` for Base, `testnet` for Base Sepolia |
-| `PORT` | | `3000` | Port the HTTP server listens on |
-| `AGENT_NAME` | | `key0 Server` | Name of your agent as shown in `/.well-known/agent.json` |
-| `AGENT_DESCRIPTION` | | `Payment-gated A2A endpoint` | Short description of your agent shown in the agent card |
-| `AGENT_URL` | | `http://localhost:PORT` | Publicly reachable URL of this server - used in the agent card and resource endpoint URLs |
-| `PROVIDER_NAME` | | `key0` | Your organization name shown in the agent card `provider` field |
-| `PROVIDER_URL` | | `https://key0.ai` | Your organization URL shown in the agent card `provider` field |
-| `PLANS` | | `[{"planId":"basic","unitAmount":"$0.10"}]` | JSON array of subscription plans - each with `planId`, `unitAmount`, and optional `description` |
-| `ROUTES_B64` | | - | Base64-encoded JSON array of per-request routes - each with `routeId`, `method`, `path`, optional `unitAmount` and `description` |
-| `CHALLENGE_TTL_SECONDS` | | `900` | How long a payment challenge remains valid before expiring (seconds) |
-| `BASE_PATH` | | - | URL path prefix for endpoints (e.g. `/a2a` mounts `/a2a/.well-known/agent.json`). The `/x402/access` endpoint is always at the root. |
-| `A2A_ENABLED` | | `true` | When `false`, disables A2A discovery (`/.well-known/agent.json`) |
-| `BACKEND_AUTH_STRATEGY` | | `none` | How key0 authenticates with `ISSUE_TOKEN_API` - `none`, `shared-secret`, or `jwt` |
-| `ISSUE_TOKEN_API_SECRET` | | - | Secret for `ISSUE_TOKEN_API` auth - Bearer token (shared-secret) or JWT signing key (jwt). Only used when `BACKEND_AUTH_STRATEGY` is not `none` |
-| `MCP_ENABLED` | | `false` | When `true`, mounts MCP routes (`/.well-known/mcp.json` + `POST /mcp`) exposing `discover` and `access` tools |
-| `LLMS_ENABLED` | | `true` | When `false`, disables generated `/llms.txt` buyer-onboarding output |
-| `SKILLS_MD_ENABLED` | | `true` | When `false`, disables generated `/skills.md` buyer workflow guide |
-| `STORAGE_BACKEND` | | `redis` | Storage backend - `redis` or `postgres` |
-| `DATABASE_URL` | | - | PostgreSQL connection URL - required when `STORAGE_BACKEND=postgres` |
-| `REDIS_URL` | ✅ | - | Redis connection URL - required for challenge state (or BullMQ refund cron when using Postgres) |
-| `KEY0_MANAGED_INFRA` | | - | Optional comma-separated list of compose-managed infra (e.g. `redis,postgres`). Auto-detected at startup via DNS; only needed as an explicit override |
-| `GAS_WALLET_PRIVATE_KEY` | | - | Private key of a wallet holding ETH on Base - enables self-contained settlement without a CDP facilitator |
-| `KEY0_WALLET_PRIVATE_KEY` | | - | Private key of `KEY0_WALLET_ADDRESS` - required for the refund cron to send USDC back to payers |
-| `REFUND_INTERVAL_MS` | | `60000` | How often the refund cron runs (ms) - only active when `KEY0_WALLET_PRIVATE_KEY` is set |
-| `REFUND_MIN_AGE_MS` | | `300000` | Minimum age (ms) a stuck `PAID` record must reach before the refund cron picks it up |
-| `REFUND_BATCH_SIZE` | | `50` | Max number of `PAID` records processed per refund cron tick |
-| `TOKEN_ISSUE_TIMEOUT_MS` | | `15000` | Timeout (ms) for each `ISSUE_TOKEN_API` call |
-| `TOKEN_ISSUE_RETRIES` | | `2` | Number of retries for transient `ISSUE_TOKEN_API` failures (does not retry on deterministic errors) |
-| `PROXY_TO_BASE_URL` | | - | Enable per-request route proxying. Requests for priced routes are proxied to this base URL after payment settlement. Required when `ROUTES_B64` includes priced routes |
-| `KEY0_PROXY_SECRET` | | - | Shared secret sent as `X-Key0-Internal-Token` header on every proxied request. Your backend validates this to ensure traffic comes from key0 |
-
-See [`docker/.env.example`](docker/.env.example) for a fully annotated example.
-
-### ISSUE_TOKEN_API Contract
-
-After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API` with the payment context merged with the matching plan:
-
-```json
-{
-  "requestId": "uuid",
-  "challengeId": "uuid",
-  "resourceId": "photo-42",
-  "planId": "basic",
-  "txHash": "0x...",
-  "unitAmount": "$0.10"
-}
-```
-
-Any extra fields you add to your `PLANS` plans are included automatically.
-
-Your endpoint can return any credential shape - the response is passed through to the client as-is:
-
-```json
-{ "token": "eyJ...", "expiresAt": "2025-01-01T00:00:00Z", "tokenType": "Bearer" }
-```
-
-```json
-{ "apiKey": "sk-123", "apiSecret": "secret", "expiresAt": "..." }
-```
-
-If the response has a `token` string field it is used directly. Otherwise the full response body is JSON-serialized into `token` with `tokenType: "custom"`, so the client can parse it.
-
-### Automatic Refunds (Standalone)
-
-When `KEY0_WALLET_PRIVATE_KEY` is set, the Docker server runs a BullMQ refund cron automatically - no extra setup needed. It scans for `PAID` challenges that were never delivered (e.g. because `ISSUE_TOKEN_API` returned an error) and sends USDC back to the payer.
-
-```
-┌──────────────┐   ┌───────────────────────────┐   ┌──────────────────┐
-│ Client Agent │   │    key0 (Docker)     │   │   Blockchain     │
-│              │   │                           │   │                  │
-│  pays USDC   │──▶│  verify on-chain          │──▶│                  │
-│              │   │  PENDING ──────────────▶ PAID │◀─ Transfer event │
-│              │   │                           │   │                  │
-│              │   │  POST ISSUE_TOKEN_API ────│──▶│  500 / timeout   │
-│              │◀──│  (token issuance fails)   │   │                  │
-│              │   │  record stays PAID        │   │                  │
-│              │   │                           │   │                  │
-│              │   │  ┌─ BullMQ cron (Redis) ─┐│   │                  │
-│              │   │  │ every REFUND_INTERVAL  ││   │                  │
-│              │   │  │ findPendingForRefund() ││   │                  │
-│              │   │  │ PAID → REFUND_PENDING  ││   │                  │
-│              │   │  │ sendUsdc() ────────────┼┼──▶│  USDC transfer   │
-│  [refunded]  │   │  │ REFUND_PENDING→REFUNDED││◀──│  txHash          │
-│              │   │  └───────────────────────┘│   │                  │
-└──────────────┘   └───────────────────────────┘   └──────────────────┘
-```
-
-```bash
-# docker/.env - add to enable refunds
-KEY0_WALLET_PRIVATE_KEY=0xYourWalletPrivateKeyHere
-REFUND_INTERVAL_MS=60000   # scan every 60s
-REFUND_MIN_AGE_MS=300000   # refund after 5-min grace period
-```
-
-> Redis is required for refund cron when running multiple replicas - BullMQ ensures only one worker broadcasts each refund transaction.
-
----
-
-## Embedded Mode
-
-Install the SDK and mount key0 as middleware inside your existing application. You keep full control over token issuance, routing, and resource verification.
-
-```
-┌──────────────┐        ┌──────────────────────────────────────────────────┐
-│ Client Agent │        │                 Your Application                  │
-│              │        │  ┌────────────────────────────────────────────┐  │
-│  discover    │───────▶│  │           key0 Middleware              │  │
-│              │◀───────│  │  /.well-known/agent.json  (auto-generated)  │  │
-│              │        │  │  /x402/access  (x402 payment + settlement)  │  │
-│  request     │───────▶│  │  [store: PENDING]                          │  │
-│              │◀───────│  │  402 + payment terms                        │  │
-│  [pays USDC on Base]  │  │                                             │  │
-│  retry +sig  │───────▶│  │  settle on-chain                           │  │
-│              │        │  │  [PENDING → PAID]                          │  │
-│              │        │  │  fetchResourceCredentials()      ──▶  your JWT/key gen  │  │
-│              │        │  │  [PAID → DELIVERED]                        │  │
-│              │◀───────│  │  AccessGrant (JWT or custom credential)     │  │
-│              │        │  └────────────────────────────────────────────┘  │
-│  /api/res    │───────▶│                                                   │
-│  Bearer: JWT │        │  Protected Routes  (validateAccessToken)          │
-│              │◀───────│  premium content                                  │
-└──────────────┘        └──────────────────────────────────────────────────┘
-```
-
-### Install
-
-```bash
-bun add @key0ai/key0
-```
-
-Optional peer dependencies:
-```bash
-bun add ioredis   # Redis-backed storage for multi-process deployments
-```
-
-### Express
-
-```typescript
+```ts
 import express from "express";
 import { key0Router, validateAccessToken } from "@key0ai/key0/express";
-import { X402Adapter, AccessTokenIssuer, RedisChallengeStore, RedisSeenTxStore } from "@key0ai/key0";
+import {
+  AccessTokenIssuer,
+  RedisChallengeStore,
+  RedisSeenTxStore,
+  X402Adapter,
+} from "@key0ai/key0";
 import Redis from "ioredis";
 
 const app = express();
 app.use(express.json());
 
 const adapter = new X402Adapter({ network: "testnet" });
-const tokenIssuer = new AccessTokenIssuer(process.env.ACCESS_TOKEN_SECRET!);
-
 const redis = new Redis(process.env.REDIS_URL!);
-const store = new RedisChallengeStore({ redis });
-const seenTxStore = new RedisSeenTxStore({ redis });
+const tokenIssuer = new AccessTokenIssuer(process.env.ACCESS_TOKEN_SECRET!);
 
 app.use(
   key0Router({
     config: {
-      agentName: "My Agent",
-      agentDescription: "A payment-gated API",
-      agentUrl: "https://my-agent.example.com",
-      providerName: "My Company",
-      providerUrl: "https://example.com",
       walletAddress: "0xYourWalletAddress" as `0x${string}`,
       network: "testnet",
-      // Subscription plans — client pays once, gets a JWT
-      plans: [
-        { planId: "basic", unitAmount: "$5.00", description: "100 API calls" },
-      ],
-      fetchResourceCredentials: async (params) => {
-        return tokenIssuer.sign(
-          { sub: params.requestId, jti: params.challengeId, resourceId: params.resourceId },
+      plans: [{ planId: "basic", unitAmount: "$0.10" }],
+      fetchResourceCredentials: async (params) =>
+        tokenIssuer.sign(
+          { sub: params.requestId, jti: params.challengeId, planId: params.planId },
           3600,
-        );
-      },
-      // Per-request routes — key0 proxies to your backend after payment
-      routes: [
-        { routeId: "weather", method: "GET" as const, path: "/api/weather/:city", unitAmount: "$0.01" },
-        { routeId: "health", method: "GET" as const, path: "/health" }, // free
-      ],
-      proxyTo: { baseUrl: "http://localhost:4000", proxySecret: process.env.KEY0_PROXY_SECRET },
+        ),
     },
     adapter,
-    store,
-    seenTxStore,
-  })
-);
-
-// Protect existing routes
-app.use("/api", validateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
-app.get("/api/data/:id", (req, res) => res.json({ data: "premium content" }));
-
-app.listen(3000);
-```
-
-### Hono
-
-```typescript
-import { Hono } from "hono";
-import { key0App, honoValidateAccessToken } from "@key0ai/key0/hono";
-import { X402Adapter, RedisChallengeStore, RedisSeenTxStore } from "@key0ai/key0";
-import Redis from "ioredis";
-
-const adapter = new X402Adapter({ network: "testnet" });
-const redis = new Redis(process.env.REDIS_URL!);
-const gate = key0App({
-  config: { /* same config */ },
-  adapter,
-  store: new RedisChallengeStore({ redis }),
-  seenTxStore: new RedisSeenTxStore({ redis }),
-});
-
-const app = new Hono();
-app.route("/", gate);
-
-const api = new Hono();
-api.use("/*", honoValidateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
-api.get("/data/:id", (c) => c.json({ data: "premium content" }));
-app.route("/api", api);
-
-export default { port: 3000, fetch: app.fetch };
-```
-
-### Fastify
-
-```typescript
-import Fastify from "fastify";
-import { key0Plugin, fastifyValidateAccessToken } from "@key0ai/key0/fastify";
-import { X402Adapter, RedisChallengeStore, RedisSeenTxStore } from "@key0ai/key0";
-import Redis from "ioredis";
-
-const fastify = Fastify();
-const adapter = new X402Adapter({ network: "testnet" });
-const redis = new Redis(process.env.REDIS_URL!);
-
-await fastify.register(key0Plugin, {
-  config: { /* same config */ },
-  adapter,
-  store: new RedisChallengeStore({ redis }),
-  seenTxStore: new RedisSeenTxStore({ redis }),
-});
-fastify.addHook("onRequest", fastifyValidateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
-
-fastify.listen({ port: 3000 });
-```
-
-### Per-Request Routes (Embedded)
-
-Gate individual routes behind micro-payments. key0 settles payment inline and calls `next()` — no JWT is issued.
-
-```typescript
-const key0 = key0Router({
-  config: {
-    // ...
-    routes: [
-      { routeId: "weather", method: "GET", path: "/api/weather/:city", unitAmount: "$0.01" },
-      { routeId: "joke", method: "GET", path: "/api/joke", unitAmount: "$0.005" },
-    ],
-  },
-  adapter, store, seenTxStore,
-});
-app.use(key0);
-
-// Gate each route — every call must include a PAYMENT-SIGNATURE header
-app.get(
-  "/api/weather/:city",
-  key0.payPerRequest("weather", {
-    onPayment: (info) => console.log(`Settled: ${info.txHash}`),
-  }),
-  (req, res) => {
-    const payment = req.key0Payment; // PaymentInfo — txHash, routeId, amount, etc.
-    res.json({ city: req.params.city, temp: 72, txHash: payment?.txHash });
-  },
-);
-
-app.get("/api/joke", key0.payPerRequest("joke"), (req, res) => {
-  res.json({ joke: "Why do programmers prefer dark mode? Bugs." });
-});
-```
-
-For Hono, use `key0.payPerRequest(routeId)` as Hono middleware. For Fastify, use `{ preHandler: key0.payPerRequest(routeId) }` in the route options.
-
-The standalone gateway alternative (transparent proxy via `proxyTo`, all traffic via `/x402/access`) is covered in the [Standalone Mode](#standalone-mode) section.
-
-### Coexistence: Plans + Routes on the Same API
-
-A seller can offer **both** subscription plans and per-request routes simultaneously. The discovery endpoint returns both:
-
-```json
-{
-  "agentName": "Weather Pro",
-  "description": "Weather data API",
-  "plans": [{ "planId": "basic", "unitAmount": "$5.00", "description": "100 API calls" }],
-  "routes": [{ "routeId": "weather", "method": "GET", "path": "/api/weather/:city", "unitAmount": "$0.01" }]
-}
-```
-
-**Config:**
-
-```typescript
-app.use(key0Router({
-  config: {
-    // ...
-    plans: [{ planId: "basic", unitAmount: "$5.00" }],
-    routes: [{ routeId: "weather", method: "GET", path: "/api/weather/:city", unitAmount: "$0.01" }],
-    proxyTo: { baseUrl: "http://localhost:4000", proxySecret: process.env.KEY0_PROXY_SECRET },
-    fetchResourceCredentials: async (params) => tokenIssuer.sign(params),
-  },
-  adapter, store, seenTxStore,
-}));
-```
-
-**Backend dual-auth pattern** — your backend checks both auth methods:
-
-```typescript
-// Your backend at localhost:4000
-app.get("/api/weather/:city", (req, res) => {
-  // Per-request path: key0 proxies with X-Key0-Internal-Token
-  const proxyToken = req.headers["x-key0-internal-token"];
-  if (proxyToken === process.env.KEY0_PROXY_SECRET) {
-    return res.json({ city: req.params.city, temp: 72 });
-  }
-
-  // Subscription path: client calls directly with Bearer JWT
-  const bearer = req.headers.authorization?.replace("Bearer ", "");
-  if (bearer && validateJwt(bearer)) {
-    return res.json({ city: req.params.city, temp: 72 });
-  }
-
-  res.status(401).json({ error: "Unauthorized" });
-});
-```
-
----
-
-### Configuration Reference
-
-#### SellerConfig
-
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `agentName` | `string` | ✅ | - | Display name in agent card |
-| `agentDescription` | `string` | ✅ | - | Agent card description |
-| `agentUrl` | `string` | ✅ | - | Public URL of your server |
-| `providerName` | `string` | ✅ | - | Your company/org name |
-| `providerUrl` | `string` | ✅ | - | Your company/org URL |
-| `walletAddress` | `0x${string}` | ✅ | - | USDC-receiving wallet |
-| `network` | `"testnet" \| "mainnet"` | ✅ | - | Base Sepolia or Base |
-| `plans` | `Plan[]` | | `[]` | Subscription plans (one-time payment → JWT) |
-| `routes` | `Route[]` | | `[]` | Per-request routes (pay-per-call → transparent proxy) |
-| `fetchResourceCredentials` | `(params) => Promise<TokenIssuanceResult>` | | - | Issue the credential after payment. Required when `plans` is non-empty |
-| `tokenIssueTimeoutMs` | `number` | | `15000` | Timeout for `fetchResourceCredentials` callback (ms) |
-| `tokenIssueRetries` | `number` | | `2` | Max retries for `fetchResourceCredentials` on transient failure |
-| `challengeTTLSeconds` | `number` | | `900` | Challenge validity window |
-| `version` | `string` | | `"1.0.0"` | Agent version shown in agent card and MCP discovery |
-| `basePath` | `string` | | `"/agent"` | Path prefix for resource endpoint URLs |
-| `resourceEndpointTemplate` | `string` | | auto | URL template (use `{resourceId}`) |
-| `gasWalletPrivateKey` | `0x${string}` | | - | Private key for self-contained settlement |
-| `redis` | `IRedisLockClient` | | - | Redis client for distributed gas wallet settlement locking across replicas |
-| `facilitatorUrl` | `string` | | CDP default | Override the x402 facilitator URL |
-| `rpcUrl` | `string` | | public RPC | Override the RPC endpoint for on-chain operations — use Alchemy or other private RPC in production |
-| `fetchResource` | `(params: FetchResourceParams) => Promise<FetchResourceResult>` | | - | Per-request proxy: called after settlement to fetch backend content. Enables standalone mode for `mode: "per-request"` plans |
-| `proxyTo` | `ProxyToConfig` | | - | Per-request proxy shorthand: builds a `fetchResource` that forwards to `baseUrl`. Supports optional `headers` (e.g. shared secret) and `pathRewrite` |
-| `onPaymentReceived` | `(grant) => Promise<void>` | | - | Fired after successful payment |
-| `onChallengeExpired` | `(challengeId) => Promise<void>` | | - | Fired when a challenge expires |
-| `a2a` | `boolean` | | `true` | When `false`, disables A2A discovery (`/.well-known/agent.json`) and JSON-RPC routing |
-| `mcp` | `boolean` | | `false` | Enable MCP server - mounts `/.well-known/mcp.json` and `POST /mcp` (Streamable HTTP) |
-
-#### Plan
-
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `planId` | `string` | ✅ | - | Unique plan identifier |
-| `unitAmount` | `string` | ✅ | - | Price (e.g. `"$0.10"`) |
-| `description` | `string` | | - | Free-form description of what the plan includes |
-| `mode` | `"subscription" \| "per-request"` | | `"subscription"` | Billing mode. `"subscription"` issues a JWT; `"per-request"` gates individual calls |
-| `routes` | `PlanRouteInfo[]` | | `[]` | Routes guarded by this per-request plan — used in the agent card and discovery response |
-
-#### Route
-
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `routeId` | `string` | ✅ | - | Unique route identifier |
-| `method` | `"GET" \| "POST" \| "PUT" \| "DELETE" \| "PATCH"` | ✅ | - | HTTP method |
-| `path` | `string` | ✅ | - | Express-style path (e.g. `"/api/weather/:city"`) |
-| `unitAmount` | `string` | | - | Price per call (e.g. `"$0.01"`). Omit for free routes |
-| `description` | `string` | | - | Human-readable description |
-
-#### PaymentInfo
-
-Available as `req.key0Payment` in embedded route handlers after successful per-request settlement.
-
-| Field | Type | Description |
-|---|---|---|
-| `txHash` | `0x${string}` | On-chain transaction hash |
-| `payer` | `string \| undefined` | Paying wallet address (when available) |
-| `planId` | `string` | Plan that was charged |
-| `amount` | `string` | Amount charged (e.g. `"$0.01"`) |
-| `method` | `string` | HTTP method of the request |
-| `path` | `string` | Route path of the request |
-| `challengeId` | `string` | Internal challenge ID (use for audit / refund tracking) |
-
-#### PlanRouteInfo
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `method` | `string` | ✅ | HTTP method (e.g. `"GET"`) |
-| `path` | `string` | ✅ | Route path (e.g. `"/api/weather/:city"`) |
-| `description` | `string` | | Human-readable description of the route |
-
-#### ProxyToConfig
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `baseUrl` | `string` | ✅ | Base URL of the backend service to proxy to |
-| `headers` | `Record<string, string>` | | Extra headers to inject (e.g. a shared secret so the backend rejects requests that bypass the gateway) |
-| `pathRewrite` | `(path: string) => string` | | Optional function to rewrite the path before forwarding |
-
-#### FetchResourceParams
-
-Passed to your `fetchResource` callback after on-chain settlement.
-
-| Field | Type | Description |
-|---|---|---|
-| `paymentInfo` | `PaymentInfo` | Payment metadata (txHash, payer, planId, amount) |
-| `method` | `string` | HTTP method of the original request |
-| `path` | `string` | Path of the original request |
-| `headers` | `Record<string, string>` | Forwarded request headers |
-| `body` | `unknown` | Request body (if any) |
-
-#### FetchResourceResult
-
-Returned by your `fetchResource` callback — used to build the `ResourceResponse` the client receives.
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `status` | `number` | ✅ | HTTP status code from the backend |
-| `body` | `unknown` | ✅ | Response body |
-| `headers` | `Record<string, string>` | | Response headers to forward to the client |
-
-#### IssueTokenParams
-
-| Field | Type | Description |
-|---|---|---|
-| `challengeId` | `string` | Use as JWT `jti` for replay prevention |
-| `requestId` | `string` | Use as JWT `sub` |
-| `resourceId` | `string` | Purchased resource |
-| `planId` | `string` | Purchased plan |
-| `txHash` | `0x${string}` | On-chain transaction hash |
-
-### Refund Cron (Embedded)
-
-When `fetchResourceCredentials` throws or the server crashes after payment but before delivery, the `ChallengeRecord` stays in `PAID` state. Wire up `processRefunds` on a schedule to detect these and send USDC back to the payer.
-
-```
-┌──────────────┐   ┌──────────────────────────────────────────────────┐   ┌──────────┐
-│ Client Agent │   │                 Your Application                  │   │Blockchain│
-│              │   │  ┌────────────────────────────────────────────┐  │   │          │
-│  pays USDC   │──▶│  │  key0 Middleware                       │  │──▶│          │
-│              │   │  │  verify on-chain                            │  │◀──│          │
-│              │   │  │  PENDING ──────────────────────────▶ PAID   │  │   │          │
-│              │   │  │  fetchResourceCredentials() throws                      │  │   │          │
-│              │◀──│  │  record stays PAID                          │  │   │          │
-│              │   │  └────────────────────────────────────────────┘  │   │          │
-│              │   │                                                   │   │          │
-│              │   │  ┌─ Your refund cron (BullMQ / setInterval) ───┐  │   │          │
-│              │   │  │ processRefunds({ store, walletPrivateKey })  │  │   │          │
-│              │   │  │ PAID → REFUND_PENDING                        │  │   │          │
-│              │   │  │ sendUsdc() ─────────────────────────────────┼──┼──▶│ USDC tx  │
-│  [refunded]  │   │  │ REFUND_PENDING → REFUNDED                   │  │◀──│ txHash   │
-│              │   │  └─────────────────────────────────────────────┘  │   │          │
-└──────────────┘   └──────────────────────────────────────────────────┘   └──────────┘
-```
-
-```typescript
-import { Queue, Worker } from "bullmq";
-import { processRefunds } from "@key0ai/key0";
-
-// Uses the same `store` passed to key0Router
-const worker = new Worker("refund-cron", async () => {
-  const results = await processRefunds({
-    store,
-    walletPrivateKey: process.env.KEY0_WALLET_PRIVATE_KEY as `0x${string}`,
-    network: "testnet",
-    minAgeMs: 5 * 60 * 1000, // 5-min grace period
-  });
-
-  for (const r of results) {
-    if (r.success) console.log(`Refunded ${r.amount} → ${r.toAddress}  tx=${r.refundTxHash}`);
-    else console.error(`Refund failed ${r.challengeId}: ${r.error}`);
-  }
-}, { connection: redis });
-
-const queue = new Queue("refund-cron", { connection: redis });
-await queue.add("process", {}, { repeat: { every: 60_000 } });
-```
-
-> The `walletPrivateKey` must correspond to `walletAddress` - the wallet that received the USDC payments.
-> Without Redis, a plain `setInterval` works for single-instance deployments (the atomic `PAID → REFUND_PENDING` CAS transition prevents double-refunds even with multiple overlapping ticks).
-> Pass `rpcUrl` to use a private RPC (e.g. Alchemy) instead of the default public endpoint — recommended for production to avoid stale-nonce errors when processing multiple sequential refunds.
-
-**Retrying failed refunds:**
-
-If a refund fails (e.g. network error), the record moves to `REFUND_FAILED`. Use `retryFailedRefunds` to re-queue them:
-
-```typescript
-import { retryFailedRefunds } from "@key0ai/key0";
-
-// Re-queue specific failed refunds - they'll be picked up by the next processRefunds run
-const requeued = await retryFailedRefunds(store, ["challengeId-1", "challengeId-2"]);
-```
-
-### Environment Variables
-
-```bash
-KEY0_NETWORK=testnet                          # "testnet" or "mainnet"
-KEY0_WALLET_ADDRESS=0xYourWalletAddress        # Receive-only wallet (no private key needed)
-ACCESS_TOKEN_SECRET=your-secret-min-32-chars        # JWT signing secret for AccessTokenIssuer
-PORT=3000                                           # Server port
-
-# Required for x402 HTTP flow with CDP facilitator (alternative to gas wallet)
-CDP_API_KEY_ID=your-cdp-api-key-id
-CDP_API_KEY_SECRET=your-cdp-api-key-secret
-
-# Optional: self-contained settlement without a facilitator
-GAS_WALLET_PRIVATE_KEY=0xYourPrivateKey
-```
-
-## Clients
-
-Any agent that can hold a wallet and sign an on-chain USDC transfer can access key0-gated APIs autonomously - no human in the loop, no pre-registration, no manual API key management. Payment is the credential.
-
-### Coding Agents (e.g. Claude Code)
-
-Coding agents like [Claude Code](https://claude.ai/code) can discover a key0 endpoint, pay for access, and receive API keys or tokens entirely on their own using an MCP wallet tool. The [Coinbase payments MCP](https://github.com/coinbase/payments-mcp) gives Claude a client-side wallet it can use to sign and broadcast USDC transfers directly:
-
-```
-1. Agent reads /.well-known/agent.json → discovers pricing and wallet address
-2. Agent calls payments-mcp to sign a USDC authorization (EIP-3009)
-3. Agent sends the signed authorization → key0 settles on-chain and returns an AccessGrant with the token/API key
-4. Agent uses the token to call the protected resource
-```
-
-No configuration or human approval required - the agent handles the full payment flow end-to-end.
-
-### MCP (Model Context Protocol)
-
-Set `mcp: true` in your config to expose key0 as an MCP server. MCP clients like Claude Desktop, Cursor, and Claude Code can discover and call your tools directly.
-
-```typescript
-app.use(
-  key0Router({
-    config: {
-      // ...existing config
-      mcp: true, // enables MCP routes
-    },
-    adapter, store, seenTxStore,
-  })
-);
-```
-
-This adds:
-- `GET /.well-known/mcp.json` - MCP discovery document
-- `POST /mcp` - Streamable HTTP transport endpoint
-
-**Two tools are exposed:**
-- `discover` - returns the catalog (plans, routes, pricing, wallet, chainId)
-- `access` - x402 payment-gated tool: call to get payment requirements, then use `payments-mcp` to complete payment via the HTTPS x402 endpoint. Includes pre-settlement resource verification, Zod payload validation, and deterministic request IDs for idempotent retry recovery
-
-**Connect from Claude Code** (`.mcp.json`):
-```json
-{
-  "mcpServers": {
-    "my-seller": {
-      "type": "http",
-      "url": "https://my-agent.example.com/mcp"
-    }
-  }
-}
-```
-
-See [`docs/mcp-integration.md`](./docs/mcp-integration.md) for architecture details and transport rationale.
-
-### Agent CLI
-
-Sellers can distribute a branded CLI binary — a standalone executable with your service URL baked in. Agents download it once, install it, and interact with your API by name.
-
-To generate CLI binaries, use the embedded SDK:
-
-```typescript
-import { buildCli } from "@key0ai/key0/cli";
-
-await buildCli({
-  name: "my-service",
-  url: "https://api.example.com",
-  targets: ["bun-linux-x64", "bun-darwin-arm64", "bun-darwin-x64"],
-  outputDir: "./dist/cli",
-});
-```
-
-**For agents — install and use:**
-
-```bash
-# Download and install once
-curl -fsSL https://cdn.example.com/cli/my-service-darwin-arm64 -o my-service
-chmod +x ./my-service
-./my-service --install
-# → { "installed": "/Users/alice/.local/bin/my-service", "inPath": true }
-
-# Use from anywhere
-my-service discover
-my-service request --plan basic
-my-service request --plan basic --payment-signature <sig>
-```
-
-All output is machine-readable JSON. Exit code `42` signals a 402 payment challenge; `0` is success.
-
-### Autonomous Agents (e.g. OpenClaw)
-
-Headless autonomous agents can do the same. Any agent runtime that supports wallet signing (via an embedded wallet, a KMS-backed key, or an MCP-compatible tool) can interact with key0 without modification - the protocol is standard HTTP + on-chain USDC.
-
-The seller never needs to pre-register clients, issue API keys manually, or manage billing. Payment is the credential.
-
-## Storage
-
-key0 requires a storage backend for challenge state and double-spend prevention. `store` and `seenTxStore` are mandatory fields. Both Redis and Postgres backends are supported.
-
-```typescript
-import { RedisChallengeStore, RedisSeenTxStore } from "@key0ai/key0";
-import Redis from "ioredis";
-
-const redis = new Redis(process.env.REDIS_URL);
-
-app.use(
-  key0Router({
-    config: { /* ... */ },
-    adapter,
-    store: new RedisChallengeStore({ redis, challengeTTLSeconds: 900 }),
+    store: new RedisChallengeStore({ redis }),
     seenTxStore: new RedisSeenTxStore({ redis }),
-  })
+  }),
 );
+
+app.use("/api", validateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
 ```
 
-Redis storage provides:
-- Atomic state transitions via Lua scripts (safe for concurrent requests)
-- Automatic TTL-based cleanup
-- Double-spend prevention with `SET NX`
+Continue with:
 
-Postgres storage uses the same interface with row-level locking for atomic transitions. The schema uses `plan_id` as the column name (matching the `planId` TypeScript field).
+- [Quickstart: Embedded](https://docs.key0.ai/quickstart/embedded)
+- [Express integration](https://docs.key0.ai/integrations/express)
+- [Hono integration](https://docs.key0.ai/integrations/hono)
+- [Fastify integration](https://docs.key0.ai/integrations/fastify)
+- [SellerConfig reference](https://docs.key0.ai/sdk-reference/seller-config)
 
-All state transitions are recorded in an immutable audit log (`IAuditStore`) for observability and debugging. Redis and Postgres audit store implementations are included.
-
-## Security
-
-- **Pre-settlement state check** - Middleware checks challenge state before on-chain settlement to prevent duplicate USDC burns (DELIVERED returns cached grant, EXPIRED/CANCELLED reject without settling)
-- **Double-spend prevention** - Each transaction hash can only be redeemed once (enforced atomically)
-- **Idempotent requests** - Same `requestId` returns the same challenge (safe to retry)
-- **On-chain verification** - Payments are verified against the actual blockchain (recipient, amount, timing)
-- **Challenge expiry** - Challenges expire after `challengeTTLSeconds` (default 15 minutes)
-- **Secret rotation** - `AccessTokenIssuer.verifyWithFallback()` supports rotating secrets with zero downtime
-
-## Token Issuance
-
-The `fetchResourceCredentials` callback gives you full control over what token is issued after a verified payment. Use the built-in `AccessTokenIssuer` for JWT issuance, or return any string (API key, opaque token, etc.):
-
-```typescript
-import { AccessTokenIssuer } from "@key0ai/key0";
-
-const tokenIssuer = new AccessTokenIssuer(process.env.ACCESS_TOKEN_SECRET!);
-
-fetchResourceCredentials: async (params) => {
-  // TTL is entirely your decision - use planId to vary it, or hardcode
-  const ttl = params.planId === "pro" ? 86400 : 3600;
-  return tokenIssuer.sign(
-    { sub: params.requestId, jti: params.challengeId, resourceId: params.resourceId, planId: params.planId },
-    ttl,
-  );
-},
-```
-
-**Zero-downtime secret rotation:**
-
-```typescript
-const decoded = await issuer.verifyWithFallback(token, [process.env.PREVIOUS_SECRET!]);
-```
-
-### Lightweight Token Validator (Backend Services)
-
-If your backend only needs to validate key0 tokens without the full SDK, use `validateKey0Token`:
-
-```typescript
-import { validateKey0Token } from "@key0ai/key0";
-
-const payload = await validateKey0Token(req.headers.authorization, {
-  secret: process.env.ACCESS_TOKEN_SECRET!,
-});
-// payload: { sub, jti, resourceId, planId, txHash, ... }
-```
-
-Supports both HS256 (shared secret) and RS256 (public key) algorithms. No blockchain connection needed.
-
-### Settlement Strategies
-
-**Facilitator (default)** - Coinbase CDP executes an EIP-3009 `transferWithAuthorization` on-chain:
+### Standalone
 
 ```bash
-CDP_API_KEY_ID=your-key-id
-CDP_API_KEY_SECRET=your-key-secret
+docker compose -f docker/docker-compose.yml --profile full up
+# Open http://localhost:3000
 ```
 
-**Gas Wallet** - self-contained settlement, no external service:
+Standalone mode exposes the payment endpoints and generates the buyer onboarding bundle from your config, including `GET /discover`, `POST /x402/access`, optional `/.well-known/agent.json`, optional `/.well-known/mcp.json`, `/llms.txt`, and `/skills.md`.
 
-```typescript
-{ gasWalletPrivateKey: process.env.GAS_WALLET_PRIVATE_KEY as `0x${string}` }
-```
+Continue with:
 
-The gas wallet must hold ETH on Base to pay transaction fees.
+- [Quickstart: Standalone](https://docs.key0.ai/quickstart/standalone)
+- [Docker deployment](https://docs.key0.ai/deployment/docker)
+- [Environment variables](https://docs.key0.ai/deployment/environment-variables)
+- [Refund architecture](https://docs.key0.ai/architecture/refunds)
 
-## Networks
+## How It Works
 
-| Network | Chain | Chain ID | USDC Contract | EIP-712 Domain Name | EIP-712 Version |
-|---|---|---|---|---|---|
-| `testnet` | Base Sepolia | 84532 | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | `USDC` | `2` |
-| `mainnet` | Base | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | `USDC` | `2` |
+1. The agent discovers your service and pricing through `GET /discover`, A2A, or MCP.
+2. key0 returns a payment challenge and verifies the USDC payment on Base.
+3. On success, key0 either returns a credential for subscription access or serves the paid route response for per-request access.
+4. If delivery fails after payment, key0 can refund the payer on-chain.
 
----
+Protocol details:
 
-## Running Examples
+- [HTTP x402 flow](https://docs.key0.ai/protocol/x402-http-flow)
+- [A2A flow](https://docs.key0.ai/protocol/a2a-flow)
+- [MCP protocol](https://docs.key0.ai/protocol/mcp)
+- [Core concepts](https://docs.key0.ai/introduction/core-concepts)
 
-The examples use Base Sepolia by default - testnet USDC is free.
+## What To Read Next
 
-**Prerequisites:**
-- Seller wallet (receive-only address)
-- Client wallet with a private key
-- Testnet USDC from the [Circle Faucet](https://faucet.circle.com/) (select Base Sepolia)
+- Getting started: [Overview](https://docs.key0.ai/introduction/overview), [Core Concepts](https://docs.key0.ai/introduction/core-concepts), [Two Modes](https://docs.key0.ai/introduction/two-modes)
+- Architecture: [Payment Flow](https://docs.key0.ai/architecture/payment-flow), [State Machine](https://docs.key0.ai/architecture/state-machine), [Storage](https://docs.key0.ai/architecture/storage), [Token Issuance](https://docs.key0.ai/architecture/token-issuance), [Refunds](https://docs.key0.ai/architecture/refunds)
+- Guides: [Building a Seller](https://docs.key0.ai/guides/building-a-seller), [Agent CLI](https://docs.key0.ai/guides/agent-cli), [Claude Code Integration](https://docs.key0.ai/guides/claude-code-integration)
+- SDK reference: [Overview](https://docs.key0.ai/sdk-reference/overview), [SellerConfig](https://docs.key0.ai/sdk-reference/seller-config), [Middleware](https://docs.key0.ai/sdk-reference/middleware), [Auth Helpers](https://docs.key0.ai/sdk-reference/auth-helpers), [Storage](https://docs.key0.ai/sdk-reference/storage), [Error Codes](https://docs.key0.ai/sdk-reference/error-codes)
+- API reference: [Overview](https://docs.key0.ai/api-reference/overview), [Agent Card](https://docs.key0.ai/api-reference/agent-card), [x402 Access](https://docs.key0.ai/api-reference/x402-access), [MCP Tools](https://docs.key0.ai/api-reference/mcp-tools), [Data Models](https://docs.key0.ai/api-reference/data-models)
+- Examples docs: [Express Seller](https://docs.key0.ai/examples/express-seller), [Hono Seller](https://docs.key0.ai/examples/hono-seller), [Standalone Service](https://docs.key0.ai/examples/standalone-service), [Backend Integration](https://docs.key0.ai/examples/backend-integration), [Embedded Pay-Per-Request](https://docs.key0.ai/examples/ppr-embedded), [Standalone Pay-Per-Request](https://docs.key0.ai/examples/ppr-standalone)
 
-```bash
-# Terminal 1 - seller
-cd examples/express-seller
-cp .env.example .env
-# set KEY0_WALLET_ADDRESS and ACCESS_TOKEN_SECRET
-bun run start
+## Examples
 
-# Terminal 2 - buyer
-cd examples/client-agent
-cp .env.example .env
-# set WALLET_PRIVATE_KEY and SELLER_URL=http://localhost:3000
-bun run start
-```
+Local example projects:
 
-| Example | Description |
-|---|---|
-| [`examples/express-seller`](./examples/express-seller) | Express photo gallery with two pricing plans |
-| [`examples/hono-seller`](./examples/hono-seller) | Same features using Hono |
-| [`examples/standalone-service`](./examples/standalone-service) | key0 as a separate service with Redis + gas wallet |
-| [`examples/refund-cron-example`](./examples/refund-cron-example) | BullMQ refund cron with Redis-backed storage |
-| [`examples/backend-integration`](./examples/backend-integration) | key0 service + backend API coordination |
-| [`examples/ppr-embedded`](./examples/ppr-embedded) | Per-request routes in embedded mode — weather + joke routes, inline settlement, no JWT |
-| [`examples/ppr-standalone`](./examples/ppr-standalone) | Per-request routes in standalone gateway mode — key0 proxies to a backend after payment |
-| [`examples/client-agent`](./examples/client-agent) | Buyer agent with real on-chain USDC payments |
-| [`examples/simple-x402-client.ts`](./examples/simple-x402-client.ts) | Minimal x402 HTTP client example (single file) |
-
----
+- [`examples/express-seller`](./examples/express-seller)
+- [`examples/hono-seller`](./examples/hono-seller)
+- [`examples/standalone-service`](./examples/standalone-service)
+- [`examples/backend-integration`](./examples/backend-integration)
+- [`examples/refund-cron-example`](./examples/refund-cron-example)
+- [`examples/ppr-embedded`](./examples/ppr-embedded)
+- [`examples/ppr-standalone`](./examples/ppr-standalone)
+- [`examples/client-agent`](./examples/client-agent)
+- [`examples/simple-x402-client.ts`](./examples/simple-x402-client.ts)
 
 ## Development
 
 ```bash
-bun install          # Install dependencies
-bun run typecheck    # Type-check
-bun run lint         # Lint with Biome v2
-bun test src/        # Run unit tests (includes express integration tests via supertest)
-                     # E2E tests require Docker + funded wallets - see e2e/README.md
-                     # CI runs e2e/preflight.ts first — auto-funds wallets via CDP faucet if low
-bun run build        # Compile to ./dist
+bun install
+bun run typecheck
+bun run lint
+bun test src/
+bun run build
 ```
 
-## Documentation
+E2E setup and wallet funding notes live in [`e2e/README.md`](./e2e/README.md).
 
-Full documentation at **[docs.key0.ai](https://docs.key0.ai/introduction/overview)**.
+## Repository Docs
 
-- [SPEC.md](./SPEC.md) - Protocol specification
-- [CONTRIBUTING.md](./CONTRIBUTING.md) - Contribution guidelines
-- [setup-ui.md](./docs/setup-ui.md) - Setup UI architecture
-- [Refund_flow.md](./docs/Refund_flow.md) - Refund state machine
-- [mcp-integration.md](./docs/mcp-integration.md) - MCP transport
-- [FLOW.md](./docs/FLOW.md) - Payment flow diagrams
+- [`SPEC.md`](./SPEC.md)
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- [`SECURITY.md`](./SECURITY.md)
+- [`docs/setup-ui.md`](./docs/setup-ui.md)
+- [`docs/FLOW.md`](./docs/FLOW.md)
+- [`docs/Refund_flow.md`](./docs/Refund_flow.md)
+- [`docs/mcp-integration.md`](./docs/mcp-integration.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/key0ai/key0)](./LICENSE)
 [![Docs](https://img.shields.io/badge/docs-key0.ai-blue)](https://docs.key0.ai/introduction/overview)
 
-key0 is an open-source commerce layer for AI agents and APIs. It lets agents discover pricing, pay in USDC on Base, and access protected services through HTTP x402, A2A, and MCP.
+key0 is an open-source commerce layer for AI agents and APIs. It lets agents discover pricing, pay in USDC on Base, and access protected services through HTTP x402, A2A, and MCP. It also generates `llms.txt`, `skills.md`, and related agent-facing surfaces to make it easier for agents to discover and interact with your offerings.
 
 For integration, deployment, protocol, and API reference docs, see [docs.key0.ai](https://docs.key0.ai/introduction/overview).
 
@@ -16,7 +16,8 @@ For integration, deployment, protocol, and API reference docs, see [docs.key0.ai
 - Sell subscription plans or per-request routes to agents.
 - Run as embedded middleware or as a standalone Docker gateway.
 - Keep your existing API and credential model.
-- Support agent-native discovery through x402, A2A, and MCP.
+- Generate agent-facing discovery artifacts like `llms.txt` and `skills.md`.
+- Support agent-native discovery and access through x402, A2A, MCP, and CLI workflows.
 - Refund automatically when payment succeeds but delivery fails.
 
 ## Choose a Mode
@@ -46,6 +47,8 @@ docker compose -f docker/docker-compose.yml --profile full up
 ```
 
 Standalone mode exposes the payment endpoints and generates the buyer onboarding bundle from your config, including `GET /discover`, `POST /x402/access`, optional `/.well-known/agent.json`, optional `/.well-known/mcp.json`, `/llms.txt`, and `/skills.md`.
+
+That gives agents multiple standard ways to discover and interact with your service out of the box: HTTP x402, A2A, MCP, generated onboarding files, and CLI distribution flows.
 
 Continue with:
 
@@ -120,6 +123,7 @@ Protocol details:
 - [A2A flow](https://docs.key0.ai/protocol/a2a-flow)
 - [MCP protocol](https://docs.key0.ai/protocol/mcp)
 - [Core concepts](https://docs.key0.ai/introduction/core-concepts)
+- [Agent CLI](https://docs.key0.ai/guides/agent-cli)
 
 ## What To Read Next
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,35 @@ Continue with:
 - [Fastify integration](https://docs.key0.ai/integrations/fastify)
 - [SellerConfig reference](https://docs.key0.ai/sdk-reference/seller-config)
 
+## Settlement
+
+Two strategies for settling USDC payments on-chain:
+
+### Facilitator (default)
+
+Coinbase CDP submits an EIP-3009 `transferWithAuthorization` on your behalf. No ETH required in your wallet.
+
+```bash
+CDP_API_KEY_ID=your-key-id
+CDP_API_KEY_SECRET=your-key-secret
+```
+
+### Gas Wallet
+
+Self-contained — no external service. The wallet signs and broadcasts the transfer directly. Must hold ETH on Base for gas fees.
+
+```bash
+# Standalone (env var)
+GAS_WALLET_PRIVATE_KEY=0xYourPrivateKey
+```
+
+```ts
+// Embedded (SellerConfig)
+config: { gasWalletPrivateKey: process.env.GAS_WALLET_PRIVATE_KEY as `0x${string}` }
+```
+
+See [Environment variables](https://docs.key0.ai/deployment/environment-variables) for the full list of settlement options.
+
 ## How It Works
 
 1. The agent discovers your service and pricing through `GET /discover`, A2A, or MCP.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ Standalone mode exposes the payment endpoints and generates the buyer onboarding
 
 That gives agents multiple standard ways to discover and interact with your service out of the box: HTTP x402, A2A, MCP, generated onboarding files, and CLI distribution flows.
 
+After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API`:
+
+```json
+{
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "challengeId": "7f3b2c1d-...",
+  "resourceId": "basic",
+  "planId": "basic",
+  "txHash": "0xabc123...",
+  "unitAmount": "$0.10"
+}
+```
+
+`unitAmount` is merged from the matching plan. Any extra fields you add to a plan are included automatically. Return any credential shape — key0 passes the response to the client as-is:
+
+```json
+{ "token": "eyJ...", "expiresAt": "2027-01-01T00:00:00Z" }
+```
+
 Continue with:
 
 - [Quickstart: Standalone](https://docs.key0.ai/quickstart/standalone)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,33 @@ app.use(
 app.use("/api", validateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
 ```
 
+For per-request billing (no JWT, inline settlement per call), use `payPerRequest` middleware:
+
+```ts
+const key0 = key0Router({
+  config: {
+    walletAddress: "0xYourWalletAddress" as `0x${string}`,
+    network: "testnet",
+    routes: [{ routeId: "weather", method: "GET" as const, path: "/api/weather/:city", unitAmount: "$0.01" }],
+  },
+  adapter,
+  store: new RedisChallengeStore({ redis }),
+  seenTxStore: new RedisSeenTxStore({ redis }),
+});
+app.use(key0);
+
+app.get(
+  "/api/weather/:city",
+  key0.payPerRequest("weather"),
+  (req, res) => {
+    const payment = req.key0Payment; // { txHash: "0x...", amount: "$0.01", ... }
+    res.json({ city: req.params.city, temp: 72, txHash: payment?.txHash });
+  },
+);
+```
+
+For Hono and Fastify variants, see [Embedded Quickstart](https://docs.key0.ai/quickstart/embedded).
+
 Continue with:
 
 - [Quickstart: Embedded](https://docs.key0.ai/quickstart/embedded)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 key0 is an open-source commerce layer for AI agents and APIs. It lets agents discover pricing, pay in USDC on Base, and access protected services through HTTP x402, A2A, and MCP.
 
-This README is intentionally short. Detailed integration, deployment, protocol, and API reference docs live in Mintlify at [docs.key0.ai](https://docs.key0.ai/introduction/overview).
+For integration, deployment, protocol, and API reference docs, see [docs.key0.ai](https://docs.key0.ai/introduction/overview).
 
 [Docs](https://docs.key0.ai/introduction/overview) · [Standalone Quickstart](https://docs.key0.ai/quickstart/standalone) · [Embedded Quickstart](https://docs.key0.ai/quickstart/embedded) · [Examples](#examples)
 

--- a/docs/superpowers/plans/2026-03-20-readme-improvements.md
+++ b/docs/superpowers/plans/2026-03-20-readme-improvements.md
@@ -1,0 +1,328 @@
+# README Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four targeted content additions to `README.md` to plug critical gaps for first-time developers evaluating Key0.
+
+**Architecture:** Pure documentation edits to a single file (`README.md`). No code changes, no tests. Each addition is a self-contained `Edit` to an exact location in the file, followed by a line-count verification and a commit.
+
+**Tech Stack:** Markdown, `git`
+
+**Spec:** `docs/superpowers/specs/2026-03-20-readme-improvements-design.md`
+
+---
+
+## File Map
+
+| File | Action |
+|---|---|
+| `README.md` | Modify — 4 targeted insertions |
+
+---
+
+## Task 1: Add ISSUE_TOKEN_API contract to Standalone Docker section
+
+**Files:**
+- Modify: `README.md:51-53`
+
+This tells standalone Docker users what their `ISSUE_TOKEN_API` endpoint needs to accept and return. It goes after the "CLI distribution flows" sentence and before the "Continue with" links.
+
+- [ ] **Step 1: Apply the edit**
+
+Insert the following block between line 51 (`...CLI distribution flows.`) and line 53 (`Continue with:`). There must be one blank line between the "CLI distribution flows." sentence and the new block, and one blank line between the new block and "Continue with:".
+
+```markdown
+After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API`:
+
+```json
+{
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "challengeId": "7f3b2c1d-...",
+  "resourceId": "basic",
+  "planId": "basic",
+  "txHash": "0xabc123...",
+  "unitAmount": "$0.10"
+}
+```
+
+`unitAmount` is merged from the matching plan. Any extra fields you add to a plan are included automatically. Return any credential shape — key0 passes the response to the client as-is:
+
+```json
+{ "token": "eyJ...", "expiresAt": "2027-01-01T00:00:00Z" }
+```
+```
+
+The `old_string` for the Edit tool:
+
+```
+That gives agents multiple standard ways to discover and interact with your service out of the box: HTTP x402, A2A, MCP, generated onboarding files, and CLI distribution flows.
+
+Continue with:
+```
+
+The `new_string`:
+
+```
+That gives agents multiple standard ways to discover and interact with your service out of the box: HTTP x402, A2A, MCP, generated onboarding files, and CLI distribution flows.
+
+After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API`:
+
+```json
+{
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "challengeId": "7f3b2c1d-...",
+  "resourceId": "basic",
+  "planId": "basic",
+  "txHash": "0xabc123...",
+  "unitAmount": "$0.10"
+}
+```
+
+`unitAmount` is merged from the matching plan. Any extra fields you add to a plan are included automatically. Return any credential shape — key0 passes the response to the client as-is:
+
+```json
+{ "token": "eyJ...", "expiresAt": "2027-01-01T00:00:00Z" }
+```
+
+Continue with:
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+wc -l README.md
+```
+
+Expected: README now has ~188 lines (171 + ~17 new lines).
+
+Check the section renders correctly by confirming these strings exist in the file:
+
+```bash
+grep -n "ISSUE_TOKEN_API" README.md
+grep -n "resourceId" README.md
+grep -n "2027-01-01" README.md
+```
+
+All three should return exactly one hit each.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add ISSUE_TOKEN_API request/response contract"
+```
+
+---
+
+## Task 2: Add `payPerRequest` embedded middleware example
+
+**Files:**
+- Modify: `README.md` — inside `### Embedded SDK`, after the subscription code block, before "Continue with:"
+
+This shows embedded per-request billing (no JWT, inline settlement) which was entirely absent from the new README. Placed immediately after the closing ` ``` ` of the subscription TypeScript block, before the "Continue with" links.
+
+- [ ] **Step 1: Apply the edit**
+
+The `old_string` for the Edit tool (the closing of the subscription block and the Continue with links):
+
+```
+app.use("/api", validateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
+```
+
+Continue with:
+```
+
+The `new_string`:
+
+```
+app.use("/api", validateAccessToken({ secret: process.env.ACCESS_TOKEN_SECRET! }));
+```
+
+For per-request billing (no JWT, inline settlement per call), use `payPerRequest` middleware:
+
+```ts
+const key0 = key0Router({
+  config: {
+    walletAddress: "0xYourWalletAddress" as `0x${string}`,
+    network: "testnet",
+    routes: [{ routeId: "weather", method: "GET" as const, path: "/api/weather/:city", unitAmount: "$0.01" }],
+  },
+  adapter,
+  store: new RedisChallengeStore({ redis }),
+  seenTxStore: new RedisSeenTxStore({ redis }),
+});
+app.use(key0);
+
+app.get(
+  "/api/weather/:city",
+  key0.payPerRequest("weather"),
+  (req, res) => {
+    const payment = req.key0Payment; // { txHash: "0x...", amount: "$0.01", ... }
+    res.json({ city: req.params.city, temp: 72, txHash: payment?.txHash });
+  },
+);
+```
+
+For Hono and Fastify variants, see [Embedded Quickstart](https://docs.key0.ai/quickstart/embedded).
+
+Continue with:
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+wc -l README.md
+grep -n "payPerRequest" README.md
+grep -n "key0Payment" README.md
+```
+
+`payPerRequest` and `key0Payment` should each appear exactly once.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add payPerRequest embedded middleware example"
+```
+
+---
+
+## Task 3: Add Settlement section
+
+**Files:**
+- Modify: `README.md` — new `## Settlement` section inserted immediately before `## How It Works`
+
+This surfaces the two settlement strategies (Facilitator and Gas Wallet) right after the quick start, where developers most often stall.
+
+- [ ] **Step 1: Apply the edit**
+
+The `old_string` for the Edit tool:
+
+```
+## How It Works
+```
+
+The `new_string`:
+
+```
+## Settlement
+
+Two strategies for settling USDC payments on-chain:
+
+### Facilitator (default)
+
+Coinbase CDP submits an EIP-3009 `transferWithAuthorization` on your behalf. No ETH required in your wallet.
+
+```bash
+CDP_API_KEY_ID=your-key-id
+CDP_API_KEY_SECRET=your-key-secret
+```
+
+### Gas Wallet
+
+Self-contained — no external service. The wallet signs and broadcasts the transfer directly. Must hold ETH on Base for gas fees.
+
+```bash
+# Standalone (env var)
+GAS_WALLET_PRIVATE_KEY=0xYourPrivateKey
+```
+
+```ts
+// Embedded (SellerConfig)
+config: { gasWalletPrivateKey: process.env.GAS_WALLET_PRIVATE_KEY as `0x${string}` }
+```
+
+See [Environment variables](https://docs.key0.ai/deployment/environment-variables) for the full list of settlement options.
+
+## How It Works
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+wc -l README.md
+grep -n "## Settlement" README.md
+grep -n "Facilitator" README.md
+grep -n "Gas Wallet" README.md
+```
+
+`## Settlement` should appear exactly once, positioned before `## How It Works`.
+
+```bash
+grep -n "## How It Works\|## Settlement" README.md
+```
+
+`## Settlement` line number should be less than `## How It Works` line number.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add settlement strategies section"
+```
+
+---
+
+## Task 4: Add Networks table
+
+**Files:**
+- Modify: `README.md` — new `## Networks` section between `## Development` and `## Repository Docs`
+
+Gives developers the chain IDs and USDC contract addresses they need to verify on-chain behavior or integrate directly.
+
+- [ ] **Step 1: Apply the edit**
+
+The `old_string` for the Edit tool:
+
+```
+E2E setup and wallet funding notes live in [`e2e/README.md`](./e2e/README.md).
+
+## Repository Docs
+```
+
+The `new_string`:
+
+```
+E2E setup and wallet funding notes live in [`e2e/README.md`](./e2e/README.md).
+
+## Networks
+
+| Network | Chain | Chain ID | USDC Contract |
+|---|---|---|---|
+| `testnet` | Base Sepolia | 84532 | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| `mainnet` | Base | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
+## Repository Docs
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+wc -l README.md
+grep -n "## Networks\|84532\|8453" README.md
+```
+
+Both chain IDs should appear exactly once each.
+
+Final line count should be ≤ 350.
+
+```bash
+wc -l README.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add networks table with chain IDs and USDC contracts"
+```
+
+---
+
+## Final Check
+
+After all four tasks are committed:
+
+- [ ] Read through the full README from top to bottom and confirm it flows naturally
+- [ ] Verify total line count is ≤ 350: `wc -l README.md`
+- [ ] Confirm no section was accidentally duplicated: `grep -c "^## " README.md` (expected: 10 top-level sections)

--- a/docs/superpowers/specs/2026-03-20-readme-improvements-design.md
+++ b/docs/superpowers/specs/2026-03-20-readme-improvements-design.md
@@ -46,27 +46,39 @@ Per-request billing in embedded mode (the `key0.payPerRequest()` middleware) is 
 
 ### Addition 1: ISSUE_TOKEN_API contract
 
-**Placement:** Inside `### Standalone Docker`, after the quick-start bash block and the paragraph describing auto-hosted endpoints, before the "Continue with" links.
+**Placement:** Inside `### Standalone Docker`, after the paragraph beginning "That gives agents multiple standard ways to discover and interact with your service out of the box: HTTP x402, A2A, MCP, generated onboarding files, and CLI distribution flows.", before the "Continue with" links.
 
-**Content:** One sentence intro, one request JSON block, one response JSON block.
+**Content:** One sentence intro, one request JSON block, one response JSON block. Use these exact field names, types, and representative values:
 
 ```
 After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API`:
 
-{request JSON block showing: requestId, challengeId, planId, txHash, unitAmount}
+```json
+{
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "challengeId": "7f3b2c1d-...",
+  "planId": "basic",
+  "txHash": "0xabc123...",
+  "unitAmount": "$0.10"
+}
+```
 
 Return any credential shape — key0 passes the response to the client as-is:
 
-{response JSON block showing: token, expiresAt}
+```json
+{ "token": "eyJ...", "expiresAt": "2027-01-01T00:00:00Z" }
+```
 ```
 
-**Size:** ~15 lines.
+All keys are camelCase strings. `unitAmount` is a dollar-prefixed string (e.g. `"$0.10"`), not a numeric value.
+
+**Size:** ~18 lines.
 
 ---
 
 ### Addition 2: Settlement strategies
 
-**Placement:** New `## Settlement` section inserted after `## How It Works`.
+**Placement:** New `## Settlement` section inserted after `## Quick Start` and before `## How It Works`. Developers who attempt the quick start often stall on settlement; this section surfaces the two options immediately after so they can unblock themselves without leaving the README.
 
 **Content:** Two subsections. No prose beyond what is required to configure each.
 
@@ -96,11 +108,13 @@ Each subsection: 2 lines of prose + one config/env snippet.
 
 ### Addition 4: `payPerRequest` embedded middleware
 
-**Placement:** Inside `### Embedded SDK`, after the subscription plan code block and its "Continue with" links. Before `## How It Works`.
+**Placement:** Inside `### Embedded SDK`, after the subscription plan code block but *before* the "Continue with" links for that section. The `payPerRequest` content is a second pattern within the same section — it is not a separate section and does not get its own "Continue with" block.
 
 **Content:** One-sentence intro explaining this is for per-request billing (no JWT, inline settlement). One Express code snippet showing:
 - `key0.payPerRequest("routeId")` applied to a route as middleware
 - `req.key0Payment` access in the handler (txHash, amount)
+
+`req.key0Payment` is the `PaymentInfo` type (`src/types/config.ts:97`), confirmed to contain: `txHash` (`0x${string}`), `payer` (`string | undefined`), `planId`, `amount`, `method`, `path`, `challengeId`. The snippet should only show `txHash` and `amount` for brevity.
 
 A note that Hono/Fastify variants are in the embedded quickstart.
 

--- a/docs/superpowers/specs/2026-03-20-readme-improvements-design.md
+++ b/docs/superpowers/specs/2026-03-20-readme-improvements-design.md
@@ -48,37 +48,36 @@ Per-request billing in embedded mode (the `key0.payPerRequest()` middleware) is 
 
 **Placement:** Inside `### Standalone Docker`, after the paragraph beginning "That gives agents multiple standard ways to discover and interact with your service out of the box: HTTP x402, A2A, MCP, generated onboarding files, and CLI distribution flows.", before the "Continue with" links.
 
-**Content:** One sentence intro, one request JSON block, one response JSON block. Use these exact field names, types, and representative values:
+**Content:** One sentence intro, one request JSON block, one response JSON block. Separated from the preceding paragraph with one blank line. No subheading.
 
-```
-After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API`:
+Field names and types sourced from `src/types/config.ts:10` (`IssueTokenParams`) and `src/helpers/docker-token-issuer.ts:30` (plan fields merged into body via `{ ...params, ...tier }`). Use these exact field names and representative values:
 
 ```json
 {
   "requestId": "550e8400-e29b-41d4-a716-446655440000",
   "challengeId": "7f3b2c1d-...",
+  "resourceId": "basic",
   "planId": "basic",
   "txHash": "0xabc123...",
   "unitAmount": "$0.10"
 }
 ```
 
+`unitAmount` is merged from the matching plan object — it is a dollar-prefixed string (e.g. `"$0.10"`). Any additional custom fields added to the plan are also merged into the body.
+
 Return any credential shape — key0 passes the response to the client as-is:
 
 ```json
 { "token": "eyJ...", "expiresAt": "2027-01-01T00:00:00Z" }
 ```
-```
 
-All keys are camelCase strings. `unitAmount` is a dollar-prefixed string (e.g. `"$0.10"`), not a numeric value.
-
-**Size:** ~18 lines.
+**Size:** ~20 lines.
 
 ---
 
 ### Addition 2: Settlement strategies
 
-**Placement:** New `## Settlement` section inserted after `## Quick Start` and before `## How It Works`. Developers who attempt the quick start often stall on settlement; this section surfaces the two options immediately after so they can unblock themselves without leaving the README.
+**Placement:** New `## Settlement` section inserted at the blank line immediately before `## How It Works` (currently README line 113). Developers who attempt the quick start often stall on settlement; this section surfaces the two options immediately after so they can unblock themselves without leaving the README. The `network` value does not appear in Settlement snippets — the `testnet` constraint from the Constraints section does not apply here.
 
 **Content:** Two subsections. No prose beyond what is required to configure each.
 
@@ -114,7 +113,7 @@ Each subsection: 2 lines of prose + one config/env snippet.
 - `key0.payPerRequest("routeId")` applied to a route as middleware
 - `req.key0Payment` access in the handler (txHash, amount)
 
-`req.key0Payment` is the `PaymentInfo` type (`src/types/config.ts:97`), confirmed to contain: `txHash` (`0x${string}`), `payer` (`string | undefined`), `planId`, `amount`, `method`, `path`, `challengeId`. The snippet should only show `txHash` and `amount` for brevity.
+`req.key0Payment` is the `PaymentInfo` type (`src/types/config.ts:97`), confirmed to contain: `txHash` (`0x${string}`), `payer` (`string | undefined`), `planId`, `amount`, `method`, `path`, `challengeId`. The snippet should only show `txHash` and `amount` for brevity. `amount` is a dollar-prefixed string (same format as `unitAmount`, e.g. `"$0.10"`).
 
 A note that Hono/Fastify variants are in the embedded quickstart.
 

--- a/docs/superpowers/specs/2026-03-20-readme-improvements-design.md
+++ b/docs/superpowers/specs/2026-03-20-readme-improvements-design.md
@@ -1,0 +1,122 @@
+# README Improvements — Design Spec
+
+**Date:** 2026-03-20
+**Branch:** `docs/readme-improvements`
+**Scope:** Plug critical content gaps in the shortened README without re-inflating it.
+
+---
+
+## Context
+
+The README was reduced from ~1,100 lines to ~171 lines across four commits. The goal was to make the root README a lightweight orientation document that points to docs.key0.ai for depth. That goal is correct. However, four practical gaps remain that a first-time developer cannot resolve from the README alone.
+
+**Primary reader:** Developers evaluating Key0 for the first time on GitHub.
+**Core message to leave them with:** Key0 handles the full commerce flow (discovery → payment → delivery → refunds) so you don't have to build it — and the fastest way to try it is Docker.
+
+---
+
+## Gaps to Address
+
+### Gap 1: ISSUE_TOKEN_API contract (standalone)
+Standalone Docker is now the primary path. After payment is verified, key0 calls the seller's `ISSUE_TOKEN_API`. The README gives no information about what key0 sends or what the endpoint should return. A developer cannot implement this callback without reading the docs.
+
+### Gap 2: Settlement strategies
+The quick-start snippets include `adapter` and `gasWalletPrivateKey` but never explain how on-chain settlement works. Developers will stall when trying to get the first payment to settle.
+
+### Gap 3: Networks table
+Testnet vs mainnet requires knowing the correct chain ID and USDC contract address. This is referenced but never stated in the current README.
+
+### Gap 4: `payPerRequest` embedded middleware
+Per-request billing in embedded mode (the `key0.payPerRequest()` middleware) is entirely absent. Standalone per-request (via Docker proxy) is covered; embedded is not.
+
+---
+
+## What We Are NOT Adding Back
+
+- Security section — the five invariants are well-served by SPEC.md and the docs
+- Full SellerConfig reference tables — these belong in the SDK reference docs
+- ASCII flow diagrams — "How It Works" covers the flow at an appropriate level of detail
+- Buyer-side agent story — "How It Works" covers this; the concrete tooling (payments-mcp, Claude Code) is niche enough for docs
+- Hono/Fastify full examples — linked from the embedded quickstart
+- Refund cron setup (embedded) — linked from the refunds architecture doc
+
+---
+
+## Design
+
+### Addition 1: ISSUE_TOKEN_API contract
+
+**Placement:** Inside `### Standalone Docker`, after the quick-start bash block and the paragraph describing auto-hosted endpoints, before the "Continue with" links.
+
+**Content:** One sentence intro, one request JSON block, one response JSON block.
+
+```
+After on-chain payment is verified, key0 POSTs to `ISSUE_TOKEN_API`:
+
+{request JSON block showing: requestId, challengeId, planId, txHash, unitAmount}
+
+Return any credential shape — key0 passes the response to the client as-is:
+
+{response JSON block showing: token, expiresAt}
+```
+
+**Size:** ~15 lines.
+
+---
+
+### Addition 2: Settlement strategies
+
+**Placement:** New `## Settlement` section inserted after `## How It Works`.
+
+**Content:** Two subsections. No prose beyond what is required to configure each.
+
+- **Facilitator (default):** Set `CDP_API_KEY_ID` + `CDP_API_KEY_SECRET`. CDP executes an EIP-3009 `transferWithAuthorization` on-chain. No ETH required in your wallet.
+- **Gas wallet:** Set `gasWalletPrivateKey` in SellerConfig (embedded) or `GAS_WALLET_PRIVATE_KEY` env var (standalone). The wallet must hold ETH on Base for gas fees. Self-contained, no external service.
+
+Each subsection: 2 lines of prose + one config/env snippet.
+
+**Size:** ~16 lines.
+
+---
+
+### Addition 3: Networks table
+
+**Placement:** After the `## Development` section, before `## Repository Docs`.
+
+**Content:** A table with columns: Network name (`testnet` / `mainnet`), Chain, Chain ID, USDC contract address.
+
+| Network | Chain | Chain ID | USDC Contract |
+|---|---|---|---|
+| `testnet` | Base Sepolia | 84532 | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| `mainnet` | Base | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
+**Size:** ~6 lines.
+
+---
+
+### Addition 4: `payPerRequest` embedded middleware
+
+**Placement:** Inside `### Embedded SDK`, after the subscription plan code block and its "Continue with" links. Before `## How It Works`.
+
+**Content:** One-sentence intro explaining this is for per-request billing (no JWT, inline settlement). One Express code snippet showing:
+- `key0.payPerRequest("routeId")` applied to a route as middleware
+- `req.key0Payment` access in the handler (txHash, amount)
+
+A note that Hono/Fastify variants are in the embedded quickstart.
+
+**Size:** ~20 lines.
+
+---
+
+## Constraints
+
+- README must stay under ~350 lines total after all additions.
+- No new sections beyond those listed above.
+- All additions should link to docs.key0.ai for depth rather than expanding inline.
+- Code snippets must use `testnet` network (matching the existing quick-start tone).
+
+---
+
+## Out of Scope
+
+Changes to docs.key0.ai, SPEC.md, CONTRIBUTING.md, or any source files.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@key0ai/key0",
 	"version": "0.5.1",
-	"description": "The commercial gateway for your AI agents and APIs. Let AI agents discover, pay for, and access your APIs autonomously — no human in the loop.",
+	"description": "The open-source commercial gateway for your AI agents and APIs. Let AI agents discover, pay for, and access your APIs autonomously — no human in the loop.",
 	"license": "AGPL-3.0",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@key0ai/key0",
-	"version": "0.5.0",
+	"version": "0.5.1",
+	"description": "The commercial gateway for your AI agents and APIs. Let AI agents discover, pay for, and access your APIs autonomously — no human in the loop.",
 	"license": "AGPL-3.0",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@key0ai/key0",
 	"version": "0.5.0",
+	"license": "AGPL-3.0",
 	"type": "module",
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",


### PR DESCRIPTION
## Summary

- Added ISSUE_TOKEN_API request/response contract to the Standalone Docker section so developers know what to implement on their backend
- Added `payPerRequest` embedded middleware example — per-request billing in embedded mode was entirely absent
- Added `## Settlement` section (Facilitator vs Gas Wallet) right after Quick Start, where developers most often stall
- Added `## Networks` table with testnet/mainnet chain IDs and USDC contract addresses

README went from 171 → 253 lines (well within 350-line target).

## Test Plan

- [ ] Read README top to bottom and confirm all four additions flow naturally
- [ ] Verify `## Settlement` appears before `## How It Works`
- [ ] Verify ISSUE_TOKEN_API JSON fields match `IssueTokenParams` (`src/types/config.ts:10`) + plan merge
- [ ] Verify `payPerRequest` snippet compiles (types match `src/integrations/pay-per-request.ts`)
- [ ] Verify USDC contract addresses against `src/types/config-shared.ts`